### PR TITLE
feat: add viewer-crd-controller rockcraft.yaml

### DIFF
--- a/viewer-crd-controller/rockcraft.yaml
+++ b/viewer-crd-controller/rockcraft.yaml
@@ -43,11 +43,17 @@ parts:
       diff $CRAFT_PART_INSTALL/third_party/licenses.csv backend/third_party_licenses/viewer.csv
       $GOBIN/go-licenses save ./backend/src/crd/controller/viewer --save_path $CRAFT_PART_INSTALL/third_party/NOTICES
 
+      # security requirement
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/ROCK images
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+      dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
+      > ${CRAFT_PART_INSTALL}/usr/share/ROCK images/dpkg.query
+
   non-root-user:
     plugin: nil
     after: [viewer-crd-controller]
     overlay-script: |
       # Create a user in the $CRAFT_OVERLAY chroot
-      groupadd -R $CRAFT_OVERLAY -g 1001 viewer-crd-controller
-      useradd -R $CRAFT_OVERLAY -M -r -u 1001 -g viewer-crd-controller viewer-crd-controller
+      groupadd -R $CRAFT_OVERLAY -g 1001 ubuntu
+      useradd -R $CRAFT_OVERLAY -M -r -u 1001 -g ubuntu ubuntu
     override-prime: |

--- a/viewer-crd-controller/rockcraft.yaml
+++ b/viewer-crd-controller/rockcraft.yaml
@@ -12,7 +12,8 @@ services:
     summary: "viewer CRD controller"
     startup: enabled
     command: controller
-    user: viewer-crd-controller
+    user: ubuntu
+
 platforms:
   amd64:
 

--- a/viewer-crd-controller/rockcraft.yaml
+++ b/viewer-crd-controller/rockcraft.yaml
@@ -1,0 +1,53 @@
+name: viewer-crd-controller
+summary: An image for the Viewer CRD Controller
+description: |
+  This image is used as part of the Charmed Kubeflow product.
+version: v1.7.0_1 # version format: <KF-upstream-version>_<Charmed-KF-version>
+license: Apache-2.0
+base: ubuntu:22.04
+build-base: ubuntu:22.04
+services:
+  controller:
+    override: replace
+    summary: "viewer CRD controller"
+    startup: enabled
+    command: controller
+    user: viewer-crd-controller
+platforms:
+  amd64:
+
+parts:
+  viewer-crd-controller:
+    plugin: go
+    source: https://github.com/kubeflow/pipelines
+    build-snaps:
+      - go/1.17/stable
+    source-type: git
+    source-tag: 2.0.0-alpha.7 # upstream tag
+    build-packages:
+      - git
+      - gcc
+      - musl-dev
+    build-environment:
+      - CGO_ENABLED: 0
+      - GOOS: linux
+    override-build: |
+      mkdir -p $CRAFT_PART_INSTALL/bin
+      mkdir -p $CRAFT_PART_INSTALL/third_party
+
+      go build -o $CRAFT_PART_INSTALL/bin/controller backend/src/crd/controller/viewer/*.go
+
+      ./hack/install-go-licenses.sh
+      $GOBIN/go-licenses check ./backend/src/crd/controller/viewer
+      $GOBIN/go-licenses csv ./backend/src/crd/controller/viewer > $CRAFT_PART_INSTALL/third_party/licenses.csv
+      diff $CRAFT_PART_INSTALL/third_party/licenses.csv backend/third_party_licenses/viewer.csv
+      $GOBIN/go-licenses save ./backend/src/crd/controller/viewer --save_path $CRAFT_PART_INSTALL/third_party/NOTICES
+
+  non-root-user:
+    plugin: nil
+    after: [viewer-crd-controller]
+    overlay-script: |
+      # Create a user in the $CRAFT_OVERLAY chroot
+      groupadd -R $CRAFT_OVERLAY -g 1001 viewer-crd-controller
+      useradd -R $CRAFT_OVERLAY -M -r -u 1001 -g viewer-crd-controller viewer-crd-controller
+    override-prime: |


### PR DESCRIPTION
Adding the `viewer-crd-controller rockcraft.yaml`.

##### Instructions to test

1. Build the rock
```
rockcraft pack -v
```
3. Import the rock into a local docker registry
```
# This step requires you to install skopeo, which you can do with apt on Ubuntu 20.04 or newer
# https://github.com/containers/skopeo/blob/main/install.md
sudo skopeo --insecure-policy copy oci-archive:<name of the rock file>.rock docker-daemon:<img name>:0.1
```
4. Run the container image
```
docker run --rm <img name>:0.1
```
##### Output
In this case we can say the output is okay, the error should go away in runtime when we pass the right arguments to the command and provide the right environment.

```
$ docker run --rm viewer:0.1
2023-05-11T12:29:13.051Z [pebble] Started daemon.
2023-05-11T12:29:13.057Z [pebble] POST /v1/services 5.057004ms 202
2023-05-11T12:29:13.057Z [pebble] Started default services with change 1.
2023-05-11T12:29:13.065Z [pebble] Service "controller" starting: controller
2023-05-11T12:29:13.084Z [controller] W0511 12:29:13.084470      14 client_config.go:617] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
2023-05-11T12:29:13.084Z [controller] W0511 12:29:13.084520      14 client_config.go:622] error creating inClusterConfig, falling back to default config: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined
2023-05-11T12:29:13.085Z [controller] 2023/05/11 12:29:13 Failed to build valid config from supplied flags: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
```