### PR TITLE
feat: pipeline rocks integration tests

### DIFF
--- a/api-server/tox.ini
+++ b/api-server/tox.ini
@@ -1,0 +1,68 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+    CHARM_REPO=https://github.com/canonical/kfp-operators.git
+    CHARM_BRANCH=main
+    LOCAL_CHARM_DIR=charm_repo
+
+[testenv:unit]
+passenv = *
+allowlist_externals =
+    bash
+    tox
+    rockcraft
+deps =
+    juju~=2.9.0
+    pytest
+    pytest-operator
+    ops
+commands =
+    # build and pack rock
+    rockcraft pack
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys" rockcraft.yaml | awk -F " " '\''{ print $2 }'\'') && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}" && \
+             sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION && \
+             docker save $ROCK > $ROCK.tar'
+    # run rock tests
+    pytest -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+
+[testenv:integration]
+passenv = *
+allowlist_externals =
+    bash
+    git
+    rm
+    tox
+    rockcraft
+deps =
+    juju~=2.9.0
+    pytest
+    pytest-operator
+    ops
+commands =
+    # build and pack rock
+    rockcraft pack
+    # clone related charm
+    rm -rf {env:LOCAL_CHARM_DIR}
+    git clone --branch {env:CHARM_BRANCH} {env:CHARM_REPO} {env:LOCAL_CHARM_DIR}
+    # upload rock to docker and microk8s cache, replace charm's container with local rock reference
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys" rockcraft.yaml | awk -F " " '\''{ print $2 }'\'') && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}" && \
+             sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION && \
+             docker save $ROCK > $ROCK.tar && \
+             microk8s ctr image import $ROCK.tar && \
+             yq e -i ".resources.oci-image.upstream-source=\"$ROCK:$VERSION\"" {env:LOCAL_CHARM_DIR}/charms/kfp-api/metadata.yaml'
+    # run charm integration test with rock
+    tox -c {env:LOCAL_CHARM_DIR} -e integration
+

--- a/frontend/tox.ini
+++ b/frontend/tox.ini
@@ -1,0 +1,68 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+    CHARM_REPO=https://github.com/canonical/kfp-operators.git
+    CHARM_BRANCH=main
+    LOCAL_CHARM_DIR=charm_repo
+
+[testenv:unit]
+passenv = *
+allowlist_externals =
+    bash
+    tox
+    rockcraft
+deps =
+    juju~=2.9.0
+    pytest
+    pytest-operator
+    ops
+commands =
+    # build and pack rock
+    rockcraft pack
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys" rockcraft.yaml | awk -F " " '\''{ print $2 }'\'') && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}" && \
+             sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION && \
+             docker save $ROCK > $ROCK.tar'
+    # run rock tests
+    pytest -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+
+[testenv:integration]
+passenv = *
+allowlist_externals =
+    bash
+    git
+    rm
+    tox
+    rockcraft
+deps =
+    juju~=2.9.0
+    pytest
+    pytest-operator
+    ops
+commands =
+    # build and pack rock
+    rockcraft pack
+    # clone related charm
+    rm -rf {env:LOCAL_CHARM_DIR}
+    git clone --branch {env:CHARM_BRANCH} {env:CHARM_REPO} {env:LOCAL_CHARM_DIR}
+    # upload rock to docker and microk8s cache, replace charm's container with local rock reference
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys" rockcraft.yaml | awk -F " " '\''{ print $2 }'\'') && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}" && \
+             sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION && \
+             docker save $ROCK > $ROCK.tar && \
+             microk8s ctr image import $ROCK.tar && \
+             yq e -i ".resources.oci-image.upstream-source=\"$ROCK:$VERSION\"" {env:LOCAL_CHARM_DIR}/charms/kfp-ui/metadata.yaml'
+    # run charm integration test with rock
+    tox -c {env:LOCAL_CHARM_DIR} -e integration
+

--- a/persistenceagent/tox.ini
+++ b/persistenceagent/tox.ini
@@ -1,0 +1,68 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+    CHARM_REPO=https://github.com/canonical/kfp-operators.git
+    CHARM_BRANCH=main
+    LOCAL_CHARM_DIR=charm_repo
+
+[testenv:unit]
+passenv = *
+allowlist_externals =
+    bash
+    tox
+    rockcraft
+deps =
+    juju~=2.9.0
+    pytest
+    pytest-operator
+    ops
+commands =
+    # build and pack rock
+    rockcraft pack
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys" rockcraft.yaml | awk -F " " '\''{ print $2 }'\'') && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}" && \
+             sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION && \
+             docker save $ROCK > $ROCK.tar'
+    # run rock tests
+    pytest -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+
+[testenv:integration]
+passenv = *
+allowlist_externals =
+    bash
+    git
+    rm
+    tox
+    rockcraft
+deps =
+    juju~=2.9.0
+    pytest
+    pytest-operator
+    ops
+commands =
+    # build and pack rock
+    rockcraft pack
+    # clone related charm
+    rm -rf {env:LOCAL_CHARM_DIR}
+    git clone --branch {env:CHARM_BRANCH} {env:CHARM_REPO} {env:LOCAL_CHARM_DIR}
+    # upload rock to docker and microk8s cache, replace charm's container with local rock reference
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys" rockcraft.yaml | awk -F " " '\''{ print $2 }'\'') && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}" && \
+             sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION && \
+             docker save $ROCK > $ROCK.tar && \
+             microk8s ctr image import $ROCK.tar && \
+             yq e -i ".resources.oci-image.upstream-source=\"$ROCK:$VERSION\"" {env:LOCAL_CHARM_DIR}/charms/kfp-persistence/metadata.yaml'
+    # run charm integration test with rock
+    tox -c {env:LOCAL_CHARM_DIR} -e integration
+

--- a/scheduledworkflow/tox.ini
+++ b/scheduledworkflow/tox.ini
@@ -1,0 +1,68 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+    CHARM_REPO=https://github.com/canonical/kfp-operators.git
+    CHARM_BRANCH=main
+    LOCAL_CHARM_DIR=charm_repo
+
+[testenv:unit]
+passenv = *
+allowlist_externals =
+    bash
+    tox
+    rockcraft
+deps =
+    juju~=2.9.0
+    pytest
+    pytest-operator
+    ops
+commands =
+    # build and pack rock
+    rockcraft pack
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys" rockcraft.yaml | awk -F " " '\''{ print $2 }'\'') && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}" && \
+             sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION && \
+             docker save $ROCK > $ROCK.tar'
+    # run rock tests
+    pytest -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+
+[testenv:integration]
+passenv = *
+allowlist_externals =
+    bash
+    git
+    rm
+    tox
+    rockcraft
+deps =
+    juju~=2.9.0
+    pytest
+    pytest-operator
+    ops
+commands =
+    # build and pack rock
+    rockcraft pack
+    # clone related charm
+    rm -rf {env:LOCAL_CHARM_DIR}
+    git clone --branch {env:CHARM_BRANCH} {env:CHARM_REPO} {env:LOCAL_CHARM_DIR}
+    # upload rock to docker and microk8s cache, replace charm's container with local rock reference
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys" rockcraft.yaml | awk -F " " '\''{ print $2 }'\'') && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}" && \
+             sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION && \
+             docker save $ROCK > $ROCK.tar && \
+             microk8s ctr image import $ROCK.tar && \
+             yq e -i ".resources.oci-image.upstream-source=\"$ROCK:$VERSION\"" {env:LOCAL_CHARM_DIR}/charms/kfp-schedwf/metadata.yaml'
+    # run charm integration test with rock
+    tox -c {env:LOCAL_CHARM_DIR} -e integration
+

--- a/viewer-crd-controller/tox.ini
+++ b/viewer-crd-controller/tox.ini
@@ -1,0 +1,68 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+    CHARM_REPO=https://github.com/canonical/kfp-operators.git
+    CHARM_BRANCH=main
+    LOCAL_CHARM_DIR=charm_repo
+
+[testenv:unit]
+passenv = *
+allowlist_externals =
+    bash
+    tox
+    rockcraft
+deps =
+    juju~=2.9.0
+    pytest
+    pytest-operator
+    ops
+commands =
+    # build and pack rock
+    rockcraft pack
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys" rockcraft.yaml | awk -F " " '\''{ print $2 }'\'') && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}" && \
+             sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION && \
+             docker save $ROCK > $ROCK.tar'
+    # run rock tests
+    pytest -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+
+[testenv:integration]
+passenv = *
+allowlist_externals =
+    bash
+    git
+    rm
+    tox
+    rockcraft
+deps =
+    juju~=2.9.0
+    pytest
+    pytest-operator
+    ops
+commands =
+    # build and pack rock
+    rockcraft pack
+    # clone related charm
+    rm -rf {env:LOCAL_CHARM_DIR}
+    git clone --branch {env:CHARM_BRANCH} {env:CHARM_REPO} {env:LOCAL_CHARM_DIR}
+    # upload rock to docker and microk8s cache, replace charm's container with local rock reference
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys" rockcraft.yaml | awk -F " " '\''{ print $2 }'\'') && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}" && \
+             sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION && \
+             docker save $ROCK > $ROCK.tar && \
+             microk8s ctr image import $ROCK.tar && \
+             yq e -i ".resources.oci-image.upstream-source=\"$ROCK:$VERSION\"" {env:LOCAL_CHARM_DIR}/charms/kfp-viewer/metadata.yaml'
+    # run charm integration test with rock
+    tox -c {env:LOCAL_CHARM_DIR} -e integration
+

--- a/visualisation-server/tox.ini
+++ b/visualisation-server/tox.ini
@@ -1,0 +1,68 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+    CHARM_REPO=https://github.com/canonical/kfp-operators.git
+    CHARM_BRANCH=main
+    LOCAL_CHARM_DIR=charm_repo
+
+[testenv:unit]
+passenv = *
+allowlist_externals =
+    bash
+    tox
+    rockcraft
+deps =
+    juju~=2.9.0
+    pytest
+    pytest-operator
+    ops
+commands =
+    # build and pack rock
+    rockcraft pack
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys" rockcraft.yaml | awk -F " " '\''{ print $2 }'\'') && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}" && \
+             sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION && \
+             docker save $ROCK > $ROCK.tar'
+    # run rock tests
+    pytest -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+
+[testenv:integration]
+passenv = *
+allowlist_externals =
+    bash
+    git
+    rm
+    tox
+    rockcraft
+deps =
+    juju~=2.9.0
+    pytest
+    pytest-operator
+    ops
+commands =
+    # build and pack rock
+    rockcraft pack
+    # clone related charm
+    rm -rf {env:LOCAL_CHARM_DIR}
+    git clone --branch {env:CHARM_BRANCH} {env:CHARM_REPO} {env:LOCAL_CHARM_DIR}
+    # upload rock to docker and microk8s cache, replace charm's container with local rock reference
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys" rockcraft.yaml | awk -F " " '\''{ print $2 }'\'') && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}" && \
+             sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION && \
+             docker save $ROCK > $ROCK.tar && \
+             microk8s ctr image import $ROCK.tar && \
+             yq e -i ".resources.oci-image.upstream-source=\"$ROCK:$VERSION\"" {env:LOCAL_CHARM_DIR}/charms/kfp-viz/metadata.yaml'
+    # run charm integration test with rock
+    tox -c {env:LOCAL_CHARM_DIR} -e integration
+


### PR DESCRIPTION
Integration tests are described in the spec. To implement those tox.ini for each ROCK has integraton test environment.

Main items:
- Build rock
- Upload it to microk8s cache
- Checkout charm's repo
- Updated metadata.yaml to point to local ROCK
- Execute charm's integration tests
- 
Refer to spec for more details.

Summary of changes:
- Added tox.ini files to pipeline rocks. Integration tests env is setup.