### PR TITLE
feat: cve scanning in rocks

### DIFF
--- a/.github/workflows/build_and_scan_rocks.yaml
+++ b/.github/workflows/build_and_scan_rocks.yaml
@@ -1,0 +1,26 @@
+name: Build and scan ROCKs, save and send scan reports
+
+on:
+  schedule:
+  # every day at 1:12AM UTC
+  - cron: '12 1 * * *'
+    secrets:
+      CVE_REPORT_JIRA_URL:
+        required: true
+
+jobs:
+  build-scan-rocks:
+    name: Build and scan ROCKs
+    strategy:
+      matrix:
+        rock:
+          - api-server
+          - persistenceagent
+          - scheduledworkflow
+          - visualisation-server
+          - viewer-crd-controller
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/build_and_scan_rock.yaml@main
+    secrets:
+      JIRA_URL: ${{ secrets.CVE_REPORT_JIRA_URL }}
+    with:
+      rock: ${{ matrix.rock }}


### PR DESCRIPTION
CVE scanning for ROCKs should be enabled on weekly schedule. The design is described in related spec.
Main design points:
- Automated workflow triggered on schedule.
- Each ROCK in the list of completed ROCKs is built (this brings in updated base image either ubuntu 20.04, 22.04 or bare), scanned for CVEs.
- Each CVE report is sent to Jira, where via automation a Jira ticket created for analysis and scheduling.
- Reports (tarball of JSONs) are uploaded as artefacts.


Summary of changes:
- Enable CVE scanning for pipeline ROCKs. Only frontend is not enabled, because it requires fixes to rockcraft.yaml.