### PR TITLE
fix: add missing dependencies

### DIFF
--- a/visualisation-server/rockcraft.yaml
+++ b/visualisation-server/rockcraft.yaml
@@ -38,6 +38,11 @@ parts:
   
   gcloud:
     plugin: nil
+    stage-package:
+    - wget
+    - curl
+    - tar
+    - openssl
     override-build: |
       set -x
       curl https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz > /tmp/google-cloud-sdk.tar.gz


### PR DESCRIPTION
Adding wget, curl, openssl and tar as they were missing, [from here](https://github.com/kubeflow/pipelines/blob/2.0.0-alpha.7/backend/Dockerfile.visualization#L24C30-L24C46).

Fixes #19 