### PR TITLE
fix: removed stage-packages from gcloud part

### DIFF
--- a/visualisation-server/rockcraft.yaml
+++ b/visualisation-server/rockcraft.yaml
@@ -38,11 +38,6 @@ parts:
   
   gcloud:
     plugin: nil
-    stage-package:
-    - wget
-    - curl
-    - tar
-    - openssl
     override-build: |
       set -x
       curl https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz > /tmp/google-cloud-sdk.tar.gz


### PR DESCRIPTION
Visualisation ROCK failed to build in GH runner due to incorrect rockcraft.yaml file.
stage-packages are not needed in gcloud part.

Logs are in https://github.com/canonical/pipelines-rocks/actions/runs/5639877801/job/15275708711


Summary of changes:
- Removed stage-packages from gcloud part.