### PR TITLE
feat: Sync ROCKS with upstream images

### DIFF
--- a/api-server/rockcraft.yaml
+++ b/api-server/rockcraft.yaml
@@ -1,7 +1,8 @@
+# Dockerfile: https://github.com/kubeflow/pipelines/blob/2.0.1/backend/Dockerfile
 name: kfp-api
 summary: An image for using Kubeflow pipelines API
 description: An image for using Kubeflow pipelines API
-version: "2.0.0-alpha.7_20.04_1"
+version: "2.0.1_20.04_1"
 base: ubuntu:20.04
 license: Apache-2.0
 platforms:
@@ -19,14 +20,17 @@ parts:
     plugin: nil
     override-build: |
       mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
-      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+      ( \
+        echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+        dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W \
+      ) > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
 
   builder:
     plugin: go
     source: https://github.com/kubeflow/pipelines.git
-    source-tag: 2.0.0-alpha.7
+    source-tag: 2.0.1
     build-snaps:
-      - go/1.17/stable
+      - go/1.20/stable
     build-environment:
       - GO111MODULE: "on"
     build-packages:
@@ -47,12 +51,10 @@ parts:
   compiler:
     plugin: python
     source: https://github.com/kubeflow/pipelines.git
-    source-tag: 2.0.0-alpha.7
-    python-requirements:
-      - ./backend/requirements.txt
+    source-tag: 2.0.1
     build-environment:
       - SNAPCRAFT_PYTHON_INTERPRETER: python3.7
-      - ARGO_VERSION: v3.3.8
+      - ARGO_VERSION: v3.3.10
     build-packages:
       - default-jdk
       - python3-setuptools
@@ -70,10 +72,7 @@ parts:
       set -e; \
       < ./samples/sample_config.json jq .[].file --raw-output | while read pipeline_yaml; do \
       pipeline_py=".${pipeline_yaml%.yaml}"; \
-      mode=`< ./samples/sample_config.json jq ".[] | select(.file == \".${pipeline_yaml}\") | (if .mode == null then \"V1\" else .mode end)" --raw-output`; \
-      mv "$pipeline_py" "${pipeline_py}.tmp"; \
-      echo 'import kfp; kfp.components.default_base_image_or_builder="gcr.io/google-appengine/python:2020-03-31-141326"' | cat - "${pipeline_py}.tmp" > "$pipeline_py"; \
-      dsl-compile --py "$pipeline_py" --output ".$pipeline_yaml" --mode "$mode" || python3 "$pipeline_py"; \
+      python3 "$pipeline_py"; \
       done
       cp -r ./samples $CRAFT_STAGE/samples
 
@@ -81,7 +80,7 @@ parts:
     after: [builder, compiler]
     plugin: nil
     source: https://github.com/kubeflow/pipelines.git
-    source-tag: 2.0.0-alpha.7
+    source-tag: 2.0.1
     build-packages:
       - ca-certificates
       - wget

--- a/api-server/rockcraft.yaml
+++ b/api-server/rockcraft.yaml
@@ -66,7 +66,7 @@ parts:
       mv ./argo-linux-amd64 $CRAFT_PART_INSTALL/argo
       cp ./backend/src/apiserver/config/sample_config.json ./samples/
       wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py
-      python3 -m pip install -r requirements.txt --no-cache-dir
+      python3 -m pip install -r ./backend/requirements.txt --no-cache-dir
       set -e; \
       < ./samples/sample_config.json jq .[].file --raw-output | while read pipeline_yaml; do \
       pipeline_py=".${pipeline_yaml%.yaml}"; \

--- a/api-server/tox.ini
+++ b/api-server/tox.ini
@@ -64,5 +64,5 @@ commands =
              microk8s ctr image import $ROCK.tar && \
              yq e -i ".resources.oci-image.upstream-source=\"$ROCK:$VERSION\"" {env:LOCAL_CHARM_DIR}/charms/kfp-api/metadata.yaml'
     # run charm integration test with rock
-    tox -c {env:LOCAL_CHARM_DIR} -e integration
+    tox -c {env:LOCAL_CHARM_DIR} -e kfp-api-integration
 

--- a/frontend/rockcraft.yaml
+++ b/frontend/rockcraft.yaml
@@ -1,7 +1,7 @@
-# Dockerfile: https://github.com/kubeflow/pipelines/blob/2.0.0/frontend/Dockerfile
+# Dockerfile: https://github.com/kubeflow/pipelines/blob/2.0.1/frontend/Dockerfile
 name: frontend
 base: ubuntu:22.04
-version: '2.0.0_22.04_1'
+version: '2.0.1_22.04_1'
 summary: Kubeflow Pipelines Management Frontend
 description: |
     This rock runs a frontend development server.
@@ -21,15 +21,17 @@ parts:
     plugin: nil
     override-build: |
       mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
-      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
-      dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
-      > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+      ( \
+        echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+        dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ \
+         -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W \
+      ) > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
 
   # This part builds the client side of the frontend container image
   frontend:
     plugin: npm
     source: https://github.com/kubeflow/pipelines.git
-    source-tag: 2.0.0
+    source-tag: 2.0.1
     build-snaps:
     - node/14/stable
     override-build: |
@@ -45,7 +47,7 @@ parts:
   backend:
     plugin: npm
     source: https://github.com/kubeflow/pipelines.git
-    source-tag: 2.0.0
+    source-tag: 2.0.1
     build-snaps:
     - node/14/stable
     override-build: |

--- a/frontend/tox.ini
+++ b/frontend/tox.ini
@@ -64,5 +64,5 @@ commands =
              microk8s ctr image import $ROCK.tar && \
              yq e -i ".resources.oci-image.upstream-source=\"$ROCK:$VERSION\"" {env:LOCAL_CHARM_DIR}/charms/kfp-ui/metadata.yaml'
     # run charm integration test with rock
-    tox -c {env:LOCAL_CHARM_DIR} -e integration
+    tox -c {env:LOCAL_CHARM_DIR} -e kfp-ui-integration
 

--- a/persistenceagent/rockcraft.yaml
+++ b/persistenceagent/rockcraft.yaml
@@ -40,11 +40,5 @@ parts:
       ./hack/install-go-licenses.sh
       $GOBIN/go-licenses check ./backend/src/agent/persistence
       $GOBIN/go-licenses csv ./backend/src/agent/persistence > $CRAFT_PART_INSTALL/third_party/licenses.csv && \
-       diff $CRAFT_PART_INSTALL/third_party/licenses.csv backend/third_party_licenses/swf.csv && \
+       diff $CRAFT_PART_INSTALL/third_party/licenses.csv backend/third_party_licenses/persistence_agent.csv && \
        $GOBIN/go-licenses save ./backend/src/agent/persistence --save_path $CRAFT_PART_INSTALL/third_party/NOTICES
-
-      # security requirement
-      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
-      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
-      dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
-      > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query

--- a/persistenceagent/rockcraft.yaml
+++ b/persistenceagent/rockcraft.yaml
@@ -1,8 +1,9 @@
+# Dockerfile: https://github.com/kubeflow/pipelines/blob/2.0.1/backend/Dockerfile.persistenceagent
 name: kfp-persistence
 summary: Reusable end-to-end ML workflows built using the Kubeflow Pipelines SDK
 description: |
   This component serves as the backend persistence agent of Kubeflow pipelines.
-version: 2.0.0-alpha.7_22.04_1 # version format: <KF-upstream-version>_<Charmed-KF-version>
+version: 2.0.1_22.04_1 # version format: <KF-upstream-version>_<Charmed-KF-version>
 license: Apache-2.0
 base: ubuntu:22.04
 run-user: _daemon_
@@ -20,11 +21,21 @@ platforms:
   amd64:
 
 parts:
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      ( \
+        echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+        dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ \
+         -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W \
+      ) > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+
   persistenceagent:
     plugin: go
     source: https://github.com/kubeflow/pipelines
     source-type: git
-    source-tag: 2.0.0-alpha.7 # upstream branch
+    source-tag: 2.0.1 # upstream branch
     build-snaps:
       - go
     build-packages:

--- a/persistenceagent/tox.ini
+++ b/persistenceagent/tox.ini
@@ -64,5 +64,5 @@ commands =
              microk8s ctr image import $ROCK.tar && \
              yq e -i ".resources.oci-image.upstream-source=\"$ROCK:$VERSION\"" {env:LOCAL_CHARM_DIR}/charms/kfp-persistence/metadata.yaml'
     # run charm integration test with rock
-    tox -c {env:LOCAL_CHARM_DIR} -e integration
+    tox -c {env:LOCAL_CHARM_DIR} -e kfp-persistence-integration
 

--- a/scheduledworkflow/rockcraft.yaml
+++ b/scheduledworkflow/rockcraft.yaml
@@ -1,8 +1,9 @@
+# Dockerfile: https://github.com/kubeflow/pipelines/blob/2.0.1/backend/Dockerfile.scheduledworkflow
 name: scheduledworkflow
 summary: Reusable end-to-end ML workflows built using the Kubeflow Pipelines SDK
 description: |
   This component serves as the backend scheduled workflow of Kubeflow pipelines.
-version: 2.0.0-alpha.7_22.04_1
+version: 2.0.1_22.04_1
 license: Apache-2.0
 base: ubuntu:22.04
 run-user: _daemon_
@@ -23,14 +24,18 @@ parts:
     plugin: nil
     override-build: |
       mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
-      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+      ( \
+        echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+        dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ \
+         -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W \
+      ) > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
 
   controller:
     plugin: go
     source: https://github.com/kubeflow/pipelines.git
-    source-tag: 2.0.0-alpha.7 # upstream branch
+    source-tag: 2.0.1 # upstream branch
     build-snaps:
-      - go/1.17/stable
+      - go/1.20/stable
     build-environment:
       - GO111MODULE: "on"
     override-build: |

--- a/scheduledworkflow/tox.ini
+++ b/scheduledworkflow/tox.ini
@@ -64,5 +64,5 @@ commands =
              microk8s ctr image import $ROCK.tar && \
              yq e -i ".resources.oci-image.upstream-source=\"$ROCK:$VERSION\"" {env:LOCAL_CHARM_DIR}/charms/kfp-schedwf/metadata.yaml'
     # run charm integration test with rock
-    tox -c {env:LOCAL_CHARM_DIR} -e integration
+    tox -c {env:LOCAL_CHARM_DIR} -e kfp-schedwf-integration
 

--- a/viewer-crd-controller/rockcraft.yaml
+++ b/viewer-crd-controller/rockcraft.yaml
@@ -1,8 +1,9 @@
+# Dockerfile: https://github.com/kubeflow/pipelines/blob/2.0.1/backend/Dockerfile.viewercontroller
 name: viewer-crd-controller
 summary: An image for the Viewer CRD Controller
 description: |
   This image is used as part of the Charmed Kubeflow product.
-version: 2.0.0-alpha.7_22.04_1 # version format: <KF-upstream-version>_<base-version>-<Charmed-KF-version>
+version: 2.0.1_22.04_1 # version format: <KF-upstream-version>_<base-version>-<Charmed-KF-version>
 license: Apache-2.0
 base: ubuntu:22.04
 build-base: ubuntu:22.04
@@ -17,13 +18,23 @@ platforms:
   amd64:
 
 parts:
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      ( \
+        echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+        dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ \
+         -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W \
+      ) > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+
   viewer-crd-controller:
     plugin: go
     source: https://github.com/kubeflow/pipelines
     build-snaps:
-      - go/1.17/stable
+      - go/1.20/stable
     source-type: git
-    source-tag: 2.0.0-alpha.7 # upstream tag
+    source-tag: 2.0.1 # upstream tag
     build-packages:
       - git
       - gcc
@@ -42,9 +53,3 @@ parts:
       $GOBIN/go-licenses csv ./backend/src/crd/controller/viewer > $CRAFT_PART_INSTALL/third_party/licenses.csv
       diff $CRAFT_PART_INSTALL/third_party/licenses.csv backend/third_party_licenses/viewer.csv
       $GOBIN/go-licenses save --force ./backend/src/crd/controller/viewer --save_path $CRAFT_PART_INSTALL/third_party/NOTICES
-
-      # security requirement
-      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
-      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
-      dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
-      > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query

--- a/viewer-crd-controller/tox.ini
+++ b/viewer-crd-controller/tox.ini
@@ -64,5 +64,5 @@ commands =
              microk8s ctr image import $ROCK.tar && \
              yq e -i ".resources.oci-image.upstream-source=\"$ROCK:$VERSION\"" {env:LOCAL_CHARM_DIR}/charms/kfp-viewer/metadata.yaml'
     # run charm integration test with rock
-    tox -c {env:LOCAL_CHARM_DIR} -e integration
+    tox -c {env:LOCAL_CHARM_DIR} -e kfp-viewer-integration
 

--- a/visualisation-server/rockcraft.yaml
+++ b/visualisation-server/rockcraft.yaml
@@ -1,7 +1,7 @@
-# Dockerfile: https://github.com/kubeflow/pipelines/blob/2.0.0-alpha.7/backend/Dockerfile.visualization
+# Dockerfile: https://github.com/kubeflow/pipelines/blob/2.0.1/backend/Dockerfile.visualization
 name: ml-pipeline-visualization-server
 base: ubuntu:20.04
-version: '2.0.0-alpha.7_20.04_1'
+version: '2.0.1_20.04_1'
 summary: ml-pipeline/visualization-server
 description: |
     ml-pipeline/visualization-server
@@ -22,11 +22,20 @@ package-repositories:
     priority: always
 
 parts:
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      ( \
+        echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+        dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W \
+      ) > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+
   python:
     plugin: python
     source: https://github.com/kubeflow/pipelines.git
     source-subdir: backend/src/apiserver/visualization
-    source-tag: 2.0.0-alpha.7
+    source-tag: 2.0.1
     stage-packages:
     - python3.6-venv
     python-requirements:
@@ -54,6 +63,6 @@ parts:
   files:
     plugin: nil
     source: https://github.com/kubeflow/pipelines.git
-    source-tag: 2.0.0-alpha.7
+    source-tag: 2.0.1
     override-build: |
       cp -r backend/src/apiserver/visualization/* $CRAFT_PART_INSTALL

--- a/visualisation-server/tox.ini
+++ b/visualisation-server/tox.ini
@@ -64,5 +64,5 @@ commands =
              microk8s ctr image import $ROCK.tar && \
              yq e -i ".resources.oci-image.upstream-source=\"$ROCK:$VERSION\"" {env:LOCAL_CHARM_DIR}/charms/kfp-viz/metadata.yaml'
     # run charm integration test with rock
-    tox -c {env:LOCAL_CHARM_DIR} -e integration
+    tox -c {env:LOCAL_CHARM_DIR} -e kfp-viz-integration
 


### PR DESCRIPTION
* Fix issues with existing ROCKS (see changes in API and Persistence Agent)
* Sync `rockcraft.yaml` files with upstream images, inspecting changes to the corresponding Dockerfiles
* Fix KFP charm-specific integration tests invocations (even for charms that don't have integration tests yet)