### PR TITLE
fix: set startup to be disabled

### DIFF
--- a/api-server/rockcraft.yaml
+++ b/api-server/rockcraft.yaml
@@ -12,7 +12,7 @@ services:
     summary: "pipelines api-server service"
     override: merge
     command: /bin/apiserver --config=/config --sampleconfig=/config/sample_config.json -logtostderr=true
-    startup: enabled
+    startup: disabled
 
 parts:
   security-team-requirement:


### PR DESCRIPTION
# Description

As part of ROCK integration it was discovered that it is more reliable to wait for all configuration to be availble before starting workload with `apiserver` ROCK. The solution is to disable startup in `rockcraft.yaml`

Summary of changes:
- Set startup of the ROCK to be disabled to ensure that workload only started by the charm when all information and configuration is ready, i.e. when all relations are established. This is required in order to prevent workload from slow recovery and to ensure faster startup.