### PR TITLE
refactor: disable `fail-fast` in integration CI

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -10,6 +10,7 @@ jobs:
     outputs:
       rockcraft-out: ${{ steps.rockcraft.outputs.rock }}
     strategy:
+      fail-fast: false
       matrix:
         rock:
           - api-server


### PR DESCRIPTION
This sets `fail-fast: false` so that integration CI failing for one rock does not block integration tests for another.  This is needed because, as is, a change to RockA will trigger RockB-RockX's CI, and if any RockB-RockX's CI fails it will cancel the CI of RockA.  This makes it hard to see if the current PR's changes are having an effect.