### PR TITLE
fix(ci): Use strict confinement for Microk8s

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -12,6 +12,6 @@ jobs:
       pull-requests: read
     secrets: inherit
     with:
-      microk8s-channel: 1.26/stable
+      microk8s-channel: 1.26-strict/stable
       juju-channel: 3.1/stable
       python-version: "3.8"

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -15,6 +15,6 @@ jobs:
       pull-requests: read
     secrets: inherit
     with:
-      microk8s-channel: 1.26/stable
+      microk8s-channel: 1.26-strict/stable
       juju-channel: 3.1/stable
       python-version: "3.8"


### PR DESCRIPTION
Update CI to use strict confinement for Microk8s. Follow up to https://github.com/canonical/pipelines-rocks/pull/55.