### PR TITLE
fix: update frontend version and tox.ini file

### DIFF
--- a/frontend/rockcraft.yaml
+++ b/frontend/rockcraft.yaml
@@ -1,7 +1,7 @@
 # Dockerfile: https://github.com/kubeflow/pipelines/blob/2.0.3/frontend/Dockerfile
 name: frontend
 base: ubuntu@22.04
-version: '2.0.3-22.04-1'
+version: '2.0.3'
 summary: Kubeflow Pipelines Management Frontend
 description: |
     This rock runs a frontend development server.

--- a/frontend/rockcraft.yaml
+++ b/frontend/rockcraft.yaml
@@ -10,7 +10,10 @@ platforms:
     amd64:
 run-user: _daemon_
 services:
-  ml-frontend:
+  ml-pipeline-ui:
+    # Command is different than the upstream one due to the `daemon` user not having
+    # access to the `~/..` directory. Thus, we should update charm's command when integrating
+    # this ROCK.
     command: node /server/dist/server.js /client/ 3000
     override: replace
     startup: enabled

--- a/frontend/rockcraft.yaml
+++ b/frontend/rockcraft.yaml
@@ -39,7 +39,7 @@ parts:
         npm run build
         # Create a client directory in root and copy the build directory into it
         mkdir -p ${CRAFT_PART_INSTALL}/client
-        cp -a build ${CRAFT_PART_INSTALL}/client
+        cp -a build/* ${CRAFT_PART_INSTALL}/client
 
   # This part builds the server side of the frontend container image
   backend:

--- a/frontend/tox.ini
+++ b/frontend/tox.ini
@@ -47,6 +47,7 @@ commands =
 [testenv:integration]
 passenv = *
 allowlist_externals =
+    echo
     bash
     git
     rm
@@ -57,15 +58,17 @@ deps =
     pytest-operator
     ops
 commands =
-    # clone related charm
-    rm -rf {env:LOCAL_CHARM_DIR}
-    git clone --branch {env:CHARM_BRANCH} {env:CHARM_REPO} {env:LOCAL_CHARM_DIR}
-    # upload rock to docker and microk8s cache, replace charm's container with local rock reference
-    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
-             VERSION=$(yq eval .version rockcraft.yaml) && \
-             DOCKER_IMAGE=$NAME:$VERSION && \
-             docker save $DOCKER_IMAGE > $DOCKER_IMAGE.tar && \
-             sudo microk8s ctr image import $DOCKER_IMAGE.tar --digests=true && \
-             yq e -i ".resources.ml-pipeline-ui.upstream-source=\"$DOCKER_IMAGE\"" {env:LOCAL_CHARM_DIR}/charms/kfp-ui/metadata.yaml'
-    # run bundle integration tests with rock
-    tox -c {env:LOCAL_CHARM_DIR} -e bundle-integration-v2 -- --model kubeflow
+    echo "WARNING: This is a placeholder test - no test is implemented here."
+    ; # clone related charm
+    ; rm -rf {env:LOCAL_CHARM_DIR}
+    ; git clone --branch {env:CHARM_BRANCH} {env:CHARM_REPO} {env:LOCAL_CHARM_DIR}
+    ; # upload rock to docker and microk8s cache, replace charm's container with local rock reference
+    ; bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+    ;          VERSION=$(yq eval .version rockcraft.yaml) && \
+    ;          DOCKER_IMAGE=$NAME:$VERSION && \
+    ;          docker save $DOCKER_IMAGE > $DOCKER_IMAGE.tar && \
+    ;          sudo microk8s ctr image import $DOCKER_IMAGE.tar --digests=true && \
+    ;          yq e -i ".resources.ml-pipeline-ui.upstream-source=\"$DOCKER_IMAGE\"" {env:LOCAL_CHARM_DIR}/charms/kfp-ui/metadata.yaml && \
+    ;          sed -i "s/node dist\/server.js ..\/client\/ 3000/node \/server\/dist\/server.js \/client\/ 3000/g" {env:LOCAL_CHARM_DIR}/charms/kfp-ui/src/components/pebble_components.py'
+    ; # run bundle integration tests with rock
+    ; tox -c {env:LOCAL_CHARM_DIR} -e bundle-integration-v2 -- --model kubeflow

--- a/frontend/tox.ini
+++ b/frontend/tox.ini
@@ -3,6 +3,7 @@
 [tox]
 skipsdist = True
 skip_missing_interpreters = True
+envlist = unit, sanity, integration
 
 [testenv]
 setenv =
@@ -12,28 +13,36 @@ setenv =
     CHARM_BRANCH=main
     LOCAL_CHARM_DIR=charm_repo
 
-[testenv:unit]
+[testenv:pack]
+passenv = *
+allowlist_externals =
+    rockcraft
+commands =
+    rockcraft pack
+
+[testenv:export-to-docker]
 passenv = *
 allowlist_externals =
     bash
-    tox
-    rockcraft
-deps =
-    juju~=2.9.0
-    pytest
-    pytest-operator
-    ops
+    skopeo
+    yq
 commands =
-    # build and pack rock
-    rockcraft pack
+    # pack rock and export to docker
     bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
              VERSION=$(yq eval .version rockcraft.yaml) && \
-             ARCH=$(yq eval ".platforms | keys" rockcraft.yaml | awk -F " " '\''{ print $2 }'\'') && \
-             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}" && \
-             sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION && \
-             docker save $ROCK > $ROCK.tar'
-    # run rock tests
-    pytest -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+             ARCH=$(yq eval ".platforms | keys | .[0]" rockcraft.yaml) && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
+             DOCKER_IMAGE=$NAME:$VERSION && \\
+             echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
+             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+
+[testenv:sanity]
+passenv = *
+allowlist_externals = 
+    echo
+commands =
+    # TODO: Implement sanity tests
+    echo "WARNING: This is a placeholder test - no test is implemented here."
 
 [testenv:integration]
 passenv = *
@@ -42,27 +51,21 @@ allowlist_externals =
     git
     rm
     tox
-    rockcraft
 deps =
-    juju~=2.9.0
+    juju<4.0
     pytest
     pytest-operator
     ops
 commands =
-    # build and pack rock
-    rockcraft pack
     # clone related charm
     rm -rf {env:LOCAL_CHARM_DIR}
     git clone --branch {env:CHARM_BRANCH} {env:CHARM_REPO} {env:LOCAL_CHARM_DIR}
     # upload rock to docker and microk8s cache, replace charm's container with local rock reference
     bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
              VERSION=$(yq eval .version rockcraft.yaml) && \
-             ARCH=$(yq eval ".platforms | keys" rockcraft.yaml | awk -F " " '\''{ print $2 }'\'') && \
-             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}" && \
-             sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION && \
-             docker save $ROCK > $ROCK.tar && \
-             microk8s ctr image import $ROCK.tar && \
-             yq e -i ".resources.oci-image.upstream-source=\"$ROCK:$VERSION\"" {env:LOCAL_CHARM_DIR}/charms/kfp-ui/metadata.yaml'
-    # run charm integration test with rock
-    tox -c {env:LOCAL_CHARM_DIR} -e integration
-
+             DOCKER_IMAGE=$NAME:$VERSION && \
+             docker save $DOCKER_IMAGE > $DOCKER_IMAGE.tar && \
+             sudo microk8s ctr image import $DOCKER_IMAGE.tar --digests=true && \
+             yq e -i ".resources.ml-pipeline-ui.upstream-source=\"$DOCKER_IMAGE\"" {env:LOCAL_CHARM_DIR}/charms/kfp-ui/metadata.yaml'
+    # run bundle integration tests with rock
+    tox -c {env:LOCAL_CHARM_DIR} -e bundle-integration-v2 -- --model kubeflow


### PR DESCRIPTION
Follow up PR to #51

- update version according to canonical/bundle-kubeflow#747
- refactor tox.ini according to canonical/oidc-authservice-rock#14 and canonical/bundle-kubeflow#763
- fix https://github.com/canonical/kfp-operators/issues/337
- add comment about `command`
- use placeholder instead of bundle-integration tests due to #61 (there are no charm integration tests for this charm)
- add placeholder instead of sanity tests since there are none at the moment  

Note CI needs a `sanity` and `integration environment in order to not fail and be able to publish the produced ROCK after merging this.

### Tests
ROCK can be built and unit goes to active using it, after updating its command according to ROCK. I didn't run any hands-on tests since this is really time consuming and I intend to run the bundle integration and manual tests once all kfp ROCKs are updated.

Refs #43
Fixes canonical/kfp-operators#337