### PR TITLE
bump viewer-crd-controller rock to ckf-1.8 (kfp 2.0.3)

### DIFF
--- a/viewer-crd-controller/rockcraft.yaml
+++ b/viewer-crd-controller/rockcraft.yaml
@@ -1,11 +1,12 @@
+# Dockerfile: https://github.com/kubeflow/pipelines/blob/2.0.3/backend/Dockerfile.viewercontroller
 name: viewer-crd-controller
 summary: An image for the Viewer CRD Controller
 description: |
   This image is used as part of the Charmed Kubeflow product.
-version: 2.0.0-alpha.7_22.04_1 # version format: <KF-upstream-version>_<base-version>-<Charmed-KF-version>
+version: 2.0.3
 license: Apache-2.0
-base: ubuntu:22.04
-build-base: ubuntu:22.04
+base: ubuntu@22.04
+build-base: ubuntu@22.04
 run-user: _daemon_
 services:
   controller:
@@ -21,9 +22,9 @@ parts:
     plugin: go
     source: https://github.com/kubeflow/pipelines
     build-snaps:
-      - go/1.17/stable
+      - go/1.20/stable
     source-type: git
-    source-tag: 2.0.0-alpha.7 # upstream tag
+    source-tag: 2.0.3
     build-packages:
       - git
       - gcc
@@ -43,7 +44,9 @@ parts:
       diff $CRAFT_PART_INSTALL/third_party/licenses.csv backend/third_party_licenses/viewer.csv
       $GOBIN/go-licenses save --force ./backend/src/crd/controller/viewer --save_path $CRAFT_PART_INSTALL/third_party/NOTICES
 
-      # security requirement
+  security-team-requirement:
+    plugin: nil
+    override-build: |
       mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
       (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
       dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \

--- a/viewer-crd-controller/tox.ini
+++ b/viewer-crd-controller/tox.ini
@@ -3,7 +3,7 @@
 [tox]
 skipsdist = True
 skip_missing_interpreters = True
-envlist = unit, sanity, integration
+envlist = pack, export-to-docker, sanity, integration
 
 [testenv]
 setenv =

--- a/viewer-crd-controller/tox.ini
+++ b/viewer-crd-controller/tox.ini
@@ -59,6 +59,8 @@ deps =
     ops
 commands =
     echo "WARNING: This is a placeholder test - no test is implemented here."
+    ; Remove warning and uncomment below once https://github.com/canonical/pipelines-rocks/issues/61
+    ; is resolved
     ; # clone related charm
     ; rm -rf {env:LOCAL_CHARM_DIR}
     ; git clone --branch {env:CHARM_BRANCH} {env:CHARM_REPO} {env:LOCAL_CHARM_DIR}

--- a/viewer-crd-controller/tox.ini
+++ b/viewer-crd-controller/tox.ini
@@ -3,6 +3,7 @@
 [tox]
 skipsdist = True
 skip_missing_interpreters = True
+envlist = unit, sanity, integration
 
 [testenv]
 setenv =
@@ -12,57 +13,61 @@ setenv =
     CHARM_BRANCH=main
     LOCAL_CHARM_DIR=charm_repo
 
-[testenv:unit]
+[testenv:pack]
+passenv = *
+allowlist_externals =
+    rockcraft
+commands =
+    rockcraft pack
+
+[testenv:export-to-docker]
 passenv = *
 allowlist_externals =
     bash
-    tox
-    rockcraft
-deps =
-    juju~=2.9.0
-    pytest
-    pytest-operator
-    ops
+    skopeo
+    yq
 commands =
-    # build and pack rock
-    rockcraft pack
+    # pack rock and export to docker
     bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
              VERSION=$(yq eval .version rockcraft.yaml) && \
-             ARCH=$(yq eval ".platforms | keys" rockcraft.yaml | awk -F " " '\''{ print $2 }'\'') && \
-             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}" && \
-             sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION && \
-             docker save $ROCK > $ROCK.tar'
-    # run rock tests
-    pytest -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+             ARCH=$(yq eval ".platforms | keys | .[0]" rockcraft.yaml) && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
+             DOCKER_IMAGE=$NAME:$VERSION && \\
+             echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
+             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+
+[testenv:sanity]
+passenv = *
+allowlist_externals =
+    echo
+commands =
+    # TODO: Implement sanity tests
+    echo "WARNING: This is a placeholder test - no test is implemented here."
 
 [testenv:integration]
 passenv = *
 allowlist_externals =
+    echo
     bash
     git
     rm
     tox
-    rockcraft
 deps =
-    juju~=2.9.0
+    juju<4.0
     pytest
     pytest-operator
     ops
 commands =
-    # build and pack rock
-    rockcraft pack
-    # clone related charm
-    rm -rf {env:LOCAL_CHARM_DIR}
-    git clone --branch {env:CHARM_BRANCH} {env:CHARM_REPO} {env:LOCAL_CHARM_DIR}
-    # upload rock to docker and microk8s cache, replace charm's container with local rock reference
-    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
-             VERSION=$(yq eval .version rockcraft.yaml) && \
-             ARCH=$(yq eval ".platforms | keys" rockcraft.yaml | awk -F " " '\''{ print $2 }'\'') && \
-             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}" && \
-             sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION && \
-             docker save $ROCK > $ROCK.tar && \
-             microk8s ctr image import $ROCK.tar && \
-             yq e -i ".resources.oci-image.upstream-source=\"$ROCK:$VERSION\"" {env:LOCAL_CHARM_DIR}/charms/kfp-viewer/metadata.yaml'
-    # run charm integration test with rock
-    tox -c {env:LOCAL_CHARM_DIR} -e integration
-
+    echo "WARNING: This is a placeholder test - no test is implemented here."
+    ; # clone related charm
+    ; rm -rf {env:LOCAL_CHARM_DIR}
+    ; git clone --branch {env:CHARM_BRANCH} {env:CHARM_REPO} {env:LOCAL_CHARM_DIR}
+    ; # upload rock to docker and microk8s cache, replace charm's container with local rock reference
+    ; bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+    ;          VERSION=$(yq eval .version rockcraft.yaml) && \
+    ;          DOCKER_IMAGE=$NAME:$VERSION && \
+    ;          docker save $DOCKER_IMAGE > $DOCKER_IMAGE.tar && \
+    ;          sudo microk8s ctr image import $DOCKER_IMAGE.tar --digests=true && \
+    ;          yq e -i ".resources.kfp-viewer-image.upstream-source=\"$DOCKER_IMAGE\"" {env:LOCAL_CHARM_DIR}/charms/kfp-viewer/metadata.yaml'
+    ; # run bundle integration tests with rock
+    ; tox -c {env:LOCAL_CHARM_DIR} -e bundle-integration-v2 -- --model kubeflow


### PR DESCRIPTION
- bump source version from `2.0.0-alpha.7` to `2.0.3`
- update according to canonical/bundle-kubeflow#747
- rename base to ubuntu@20.04 as per new `rockcraft` syntax
- use `1.20/stable` snap for Go
- refactor `tox.ini` according to canonical/oidc-authservice-rock#14 and canonical/bundle-kubeflow#763
- use placeholder instead of bundle-integration tests due to #61 (there are no charm integration tests for this charm)
- add placeholder instead of sanity tests since there are none at the moment

Note CI needs a `sanity` and `integration` environment in order to not fail and be able to publish the produced ROCK after merging this.

### Testing
ROCK can be built and unit goes to active using it. I didn't run any hands-on tests since bundle-integration and manual tests will be run once all kfp ROCKs are updated.

Closes #48