### PR TITLE
chore: bump persistenceagent to 2.0.5

### DIFF
--- a/persistenceagent/rockcraft.yaml
+++ b/persistenceagent/rockcraft.yaml
@@ -1,9 +1,9 @@
-# Dockerfile: https://github.com/kubeflow/pipelines/blob/2.0.3/backend/Dockerfile.persistenceagent
+# Dockerfile: https://github.com/kubeflow/pipelines/blob/2.0.5/backend/Dockerfile.persistenceagent
 name: persistenceagent
 summary: Reusable end-to-end ML workflows built using the Kubeflow Pipelines SDK
 description: |
   This component serves as the backend persistence agent of Kubeflow pipelines.
-version: 2.0.3
+version: 2.0.5
 license: Apache-2.0
 base: ubuntu:22.04
 run-user: _daemon_
@@ -25,7 +25,7 @@ parts:
     plugin: go
     source: https://github.com/kubeflow/pipelines
     source-type: git
-    source-tag: 2.0.3
+    source-tag: 2.0.5
     build-snaps:
       - go/1.20/stable
     build-packages:


### PR DESCRIPTION
This should be merged after https://github.com/canonical/pipelines-rocks/pull/72.

Ref #69