### PR TITLE
Update persistenceagent to 2.2.0

### DIFF
--- a/persistenceagent/rockcraft.yaml
+++ b/persistenceagent/rockcraft.yaml
@@ -1,11 +1,13 @@
-# Dockerfile: https://github.com/kubeflow/pipelines/blob/2.0.5/backend/Dockerfile.persistenceagent
+# Based on: https://github.com/kubeflow/pipelines/blob/sdk-2.2.0/backend/Dockerfile.persistenceagent
 name: persistenceagent
 summary: Reusable end-to-end ML workflows built using the Kubeflow Pipelines SDK
 description: |
   This component serves as the backend persistence agent of Kubeflow pipelines.
-version: 2.0.5
+version: "2.2.0"
 license: Apache-2.0
-base: ubuntu:22.04
+base: ubuntu@22.04
+platforms:
+  amd64:
 run-user: _daemon_
 services:
   persistenceagent:
@@ -17,15 +19,21 @@ services:
       TTL_SECONDS_AFTER_WORKFLOW_FINISH: 86400
       NUM_WORKERS: 2
     command: bash -c 'persistence_agent --logtostderr=true --namespace=$NAMESPACE --ttlSecondsAfterWorkflowFinish=$TTL_SECONDS_AFTER_WORKFLOW_FINISH --numWorker $NUM_WORKERS'
-platforms:
-  amd64:
 
 parts:
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+      dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
+      > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+
   persistenceagent:
     plugin: go
     source: https://github.com/kubeflow/pipelines
     source-type: git
-    source-tag: 2.0.5
+    source-tag: 2.2.0
     build-snaps:
       - go/1.20/stable
     build-packages:
@@ -43,9 +51,3 @@ parts:
       $GOBIN/go-licenses csv ./backend/src/agent/persistence > $CRAFT_PART_INSTALL/third_party/licenses.csv && \
        diff $CRAFT_PART_INSTALL/third_party/licenses.csv backend/third_party_licenses/persistence_agent.csv && \
        $GOBIN/go-licenses save ./backend/src/agent/persistence --save_path $CRAFT_PART_INSTALL/third_party/NOTICES
-
-      # security requirement
-      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
-      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
-      dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
-      > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query

--- a/persistenceagent/rockcraft.yaml
+++ b/persistenceagent/rockcraft.yaml
@@ -18,7 +18,9 @@ services:
       NAMESPACE: ""
       TTL_SECONDS_AFTER_WORKFLOW_FINISH: 86400
       NUM_WORKERS: 2
-    command: bash -c 'persistence_agent --logtostderr=true --namespace=$NAMESPACE --ttlSecondsAfterWorkflowFinish=$TTL_SECONDS_AFTER_WORKFLOW_FINISH --numWorker $NUM_WORKERS'
+      LOG_LEVEL: "info"
+      EXECUTIONTYPE: "Workflow"
+    command: bash -c 'persistence_agent --logtostderr=true --namespace=$NAMESPACE --ttlSecondsAfterWorkflowFinish=$TTL_SECONDS_AFTER_WORKFLOW_FINISH --numWorker $NUM_WORKERS --executionType ${EXECUTIONTYPE} --logLevel=${LOG_LEVEL}'
 
 parts:
   security-team-requirement:
@@ -35,7 +37,7 @@ parts:
     source-type: git
     source-tag: 2.2.0
     build-snaps:
-      - go/1.20/stable
+      - go/1.21/stable
     build-packages:
       - git
       - openssl

--- a/persistenceagent/rockcraft.yaml
+++ b/persistenceagent/rockcraft.yaml
@@ -1,4 +1,4 @@
-# Based on: https://github.com/kubeflow/pipelines/blob/sdk-2.2.0/backend/Dockerfile.persistenceagent
+# Based on: https://github.com/kubeflow/pipelines/blob/2.2.0/backend/Dockerfile.persistenceagent
 name: persistenceagent
 summary: Reusable end-to-end ML workflows built using the Kubeflow Pipelines SDK
 description: |
@@ -20,7 +20,7 @@ services:
       NUM_WORKERS: 2
       LOG_LEVEL: "info"
       EXECUTIONTYPE: "Workflow"
-    command: bash -c 'persistence_agent --logtostderr=true --namespace=$NAMESPACE --ttlSecondsAfterWorkflowFinish=$TTL_SECONDS_AFTER_WORKFLOW_FINISH --numWorker $NUM_WORKERS --executionType ${EXECUTIONTYPE} --logLevel=${LOG_LEVEL}'
+    command: bash -c 'persistence_agent --logtostderr=true --namespace=$NAMESPACE --ttlSecondsAfterWorkflowFinish=$TTL_SECONDS_AFTER_WORKFLOW_FINISH --numWorker $NUM_WORKERS --executionType $EXECUTIONTYPE --logLevel=$LOG_LEVEL'
 
 parts:
   security-team-requirement:

--- a/persistenceagent/tests/test_rock.py
+++ b/persistenceagent/tests/test_rock.py
@@ -1,0 +1,73 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+import random
+import pytest
+import string
+import subprocess
+import yaml
+
+from charmed_kubeflow_chisme.rock import CheckRock
+
+
+@pytest.fixture()
+def rock_test_env(tmpdir):
+    """Yields a temporary directory and random docker container name, then cleans them up after."""
+    container_name = "".join(
+        [str(i) for i in random.choices(string.ascii_lowercase, k=8)]
+    )
+    yield tmpdir, container_name
+
+    try:
+        subprocess.run(["docker", "rm", container_name])
+    except Exception:
+        pass
+    # tmpdir fixture we use here should clean up the other files for us
+
+
+@pytest.mark.abort_on_fail
+def test_rock(rock_test_env):
+    """Test rock."""
+    temp_dir, container_name = rock_test_env
+    check_rock = CheckRock("rockcraft.yaml")
+    rock_image = check_rock.get_name()
+    rock_version = check_rock.get_version()
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
+
+    # assert we have the expected files
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "which persistence_agent",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /usr/bin/persistence_agent",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /third_party",
+        ],
+        check=True,
+    )
+

--- a/persistenceagent/tox.ini
+++ b/persistenceagent/tox.ini
@@ -60,17 +60,15 @@ deps =
     ops
 commands =
     echo "WARNING: This is a placeholder test - no test is implemented here."
-    ; Remove warning and uncomment below once https://github.com/canonical/kfp-operators/issues/377
-    ; is resolved
-    ; # clone related charm
-    ; rm -rf {env:LOCAL_CHARM_DIR}
-    ; git clone --branch {env:CHARM_BRANCH} {env:CHARM_REPO} {env:LOCAL_CHARM_DIR}
-    ; # upload rock to docker and microk8s cache, replace charm's container with local rock reference
-    ; bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
-    ;          VERSION=$(yq eval .version rockcraft.yaml) && \
-    ;          DOCKER_IMAGE=$NAME:$VERSION && \
-    ;          docker save $DOCKER_IMAGE > $DOCKER_IMAGE.tar && \
-    ;          sudo microk8s ctr image import $DOCKER_IMAGE.tar --digests=true && \
-    ;          yq e -i ".resources.oci-image.upstream-source=\"$DOCKER_IMAGE\"" {env:LOCAL_CHARM_DIR}/charms/kfp-persistence/metadata.yaml'
-    ; # run bundle integration tests with rock
-    ; tox -c {env:LOCAL_CHARM_DIR} -e bundle-integration-v2 -- --model kubeflow
+    # clone related charm
+    rm -rf {env:LOCAL_CHARM_DIR}
+    git clone --branch {env:CHARM_BRANCH} {env:CHARM_REPO} {env:LOCAL_CHARM_DIR}
+    # upload rock to docker and microk8s cache, replace charm's container with local rock reference
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             DOCKER_IMAGE=$NAME:$VERSION && \
+             docker save $DOCKER_IMAGE > $DOCKER_IMAGE.tar && \
+             sudo microk8s ctr image import $DOCKER_IMAGE.tar --digests=true && \
+             yq e -i ".resources.oci-image.upstream-source=\"$DOCKER_IMAGE\"" {env:LOCAL_CHARM_DIR}/charms/kfp-persistence/metadata.yaml'
+    # run bundle integration tests with rock
+    tox -c {env:LOCAL_CHARM_DIR} -e bundle-integration-v2 -- --model kubeflow

--- a/persistenceagent/tox.ini
+++ b/persistenceagent/tox.ini
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 [tox]
 skipsdist = True

--- a/persistenceagent/tox.ini
+++ b/persistenceagent/tox.ini
@@ -60,15 +60,16 @@ deps =
     ops
 commands =
     echo "WARNING: This is a placeholder test - no test is implemented here."
-    # clone related charm
-    rm -rf {env:LOCAL_CHARM_DIR}
-    git clone --branch {env:CHARM_BRANCH} {env:CHARM_REPO} {env:LOCAL_CHARM_DIR}
-    # upload rock to docker and microk8s cache, replace charm's container with local rock reference
-    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
-             VERSION=$(yq eval .version rockcraft.yaml) && \
-             DOCKER_IMAGE=$NAME:$VERSION && \
-             docker save $DOCKER_IMAGE > $DOCKER_IMAGE.tar && \
-             sudo microk8s ctr image import $DOCKER_IMAGE.tar --digests=true && \
-             yq e -i ".resources.oci-image.upstream-source=\"$DOCKER_IMAGE\"" {env:LOCAL_CHARM_DIR}/charms/kfp-persistence/metadata.yaml'
-    # run bundle integration tests with rock
-    tox -c {env:LOCAL_CHARM_DIR} -e bundle-integration-v2 -- --model kubeflow
+    # Tests bellow are failing (charms are unable to build)
+    ; # clone related charm
+    ; rm -rf {env:LOCAL_CHARM_DIR}
+    ; git clone --branch {env:CHARM_BRANCH} {env:CHARM_REPO} {env:LOCAL_CHARM_DIR}
+    ; # upload rock to docker and microk8s cache, replace charm's container with local rock reference
+    ; bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+    ;          VERSION=$(yq eval .version rockcraft.yaml) && \
+    ;          DOCKER_IMAGE=$NAME:$VERSION && \
+    ;          docker save $DOCKER_IMAGE > $DOCKER_IMAGE.tar && \
+    ;          sudo microk8s ctr image import $DOCKER_IMAGE.tar --digests=true && \
+    ;          yq e -i ".resources.oci-image.upstream-source=\"$DOCKER_IMAGE\"" {env:LOCAL_CHARM_DIR}/charms/kfp-persistence/metadata.yaml'
+    ; # run bundle integration tests with rock
+    ; tox -c {env:LOCAL_CHARM_DIR} -e bundle-integration-v2 -- --model kubeflow

--- a/persistenceagent/tox.ini
+++ b/persistenceagent/tox.ini
@@ -38,11 +38,12 @@ commands =
 
 [testenv:sanity]
 passenv = *
-allowlist_externals =
-    echo
+deps =
+    pytest
+    charmed-kubeflow-chisme
 commands =
-    # TODO: Implement sanity tests
-    echo "WARNING: This is a placeholder test - no test is implemented here."
+    # run rock tests
+    pytest -s -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
 
 [testenv:integration]
 passenv = *


### PR DESCRIPTION
closes: https://github.com/canonical/pipelines-rocks/issues/84

I have compared this file https://github.com/kubeflow/pipelines/blob/2.0.5/backend/Dockerfile.persistenceagent for tags [2.0.5](https://github.com/kubeflow/pipelines/blob/2.0.5/backend/Dockerfile.persistenceagent) and [2.2.0](https://github.com/kubeflow/pipelines/blob/2.2.0/backend/Dockerfile.persistenceagent). Changes: 
- Go bump 
- new env variables

Other changes:
- rewritten  the `rockcraft.yaml` based on up to date process 
- added tests for sanity

For experiment I tried to run the integration test for the rock but the bundle test is [failing to build charms](https://github.com/canonical/pipelines-rocks/actions/runs/9269011939/job/25501498014#step:9:562).