### PR TITLE
Update scheduledworkflow to 2.2.0

### DIFF
--- a/scheduledworkflow/rockcraft.yaml
+++ b/scheduledworkflow/rockcraft.yaml
@@ -3,7 +3,7 @@ name: scheduledworkflow
 summary: Reusable end-to-end ML workflows built using the Kubeflow Pipelines SDK
 description: |
   This component serves as the backend scheduled workflow of Kubeflow pipelines.
-version: 2.0.5
+version: 2.2.0
 license: Apache-2.0
 base: ubuntu@22.04
 run-user: _daemon_
@@ -11,11 +11,12 @@ services:
   controller:
     override: replace
     summary: "scheduled workflow controller service"
-    command: bash -c '/bin/controller --logtostderr=true --namespace=${NAMESPACE}'
+    command: bash -c '/bin/controller --logtostderr=true --namespace=${NAMESPACE} --logLevel=${LOG_LEVEL}'
     startup: enabled
     environment:
       NAMESPACE: ""
       CRON_SCHEDULE_TIMEZONE: UTC
+      LOG_LEVEL: "info"
 platforms:
   amd64:
 
@@ -29,9 +30,9 @@ parts:
   controller:
     plugin: go
     source: https://github.com/kubeflow/pipelines.git
-    source-tag: 2.0.5
+    source-tag: 2.2.0
     build-snaps:
-      - go/1.20/stable
+      - go/1.21/stable
     build-environment:
       - GO111MODULE: "on"
     override-build: |

--- a/scheduledworkflow/rockcraft.yaml
+++ b/scheduledworkflow/rockcraft.yaml
@@ -1,11 +1,13 @@
-# Dockerfile: https://github.com/kubeflow/pipelines/blob/2.0.5/backend/Dockerfile.scheduledworkflow
+# Based on: https://github.com/kubeflow/pipelines/blob/2.2.0/backend/Dockerfile.scheduledworkflow
 name: scheduledworkflow
 summary: Reusable end-to-end ML workflows built using the Kubeflow Pipelines SDK
 description: |
   This component serves as the backend scheduled workflow of Kubeflow pipelines.
-version: 2.2.0
+version: "2.2.0"
 license: Apache-2.0
 base: ubuntu@22.04
+platforms:
+  amd64:
 run-user: _daemon_
 services:
   controller:
@@ -17,8 +19,6 @@ services:
       NAMESPACE: ""
       CRON_SCHEDULE_TIMEZONE: UTC
       LOG_LEVEL: "info"
-platforms:
-  amd64:
 
 parts:
   security-team-requirement:

--- a/scheduledworkflow/tests/test_rock.py
+++ b/scheduledworkflow/tests/test_rock.py
@@ -1,0 +1,59 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+import random
+import pytest
+import string
+import subprocess
+
+from charmed_kubeflow_chisme.rock import CheckRock
+
+
+@pytest.fixture()
+def rock_test_env(tmpdir):
+    """Yields a temporary directory and random docker container name, then cleans them up after."""
+    container_name = "".join(
+        [str(i) for i in random.choices(string.ascii_lowercase, k=8)]
+    )
+    yield tmpdir, container_name
+
+    try:
+        subprocess.run(["docker", "rm", container_name])
+    except Exception:
+        pass
+    # tmpdir fixture we use here should clean up the other files for us
+
+
+@pytest.mark.abort_on_fail
+def test_rock(rock_test_env):
+    """Test rock."""
+    temp_dir, container_name = rock_test_env
+    check_rock = CheckRock("rockcraft.yaml")
+    rock_image = check_rock.get_name()
+    rock_version = check_rock.get_version()
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
+
+    # assert we have the expected files
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /bin/controller",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /third_party",
+        ],
+        check=True,
+    )

--- a/scheduledworkflow/tox.ini
+++ b/scheduledworkflow/tox.ini
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 [tox]
 skipsdist = True
@@ -38,11 +38,12 @@ commands =
 
 [testenv:sanity]
 passenv = *
-allowlist_externals =
-    echo
+deps =
+    pytest
+    charmed-kubeflow-chisme
 commands =
-    # TODO: Implement sanity tests
-    echo "WARNING: This is a placeholder test - no test is implemented here."
+    # run rock tests
+    pytest -s -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
 
 [testenv:integration]
 passenv = *
@@ -60,8 +61,7 @@ deps =
     ops
 commands =
     echo "WARNING: This is a placeholder test - no test is implemented here."
-    ; Remove warning and uncomment below once https://github.com/canonical/pipelines-rocks/issues/61
-    ; is resolved
+    # Tests bellow are failing (charms are unable to build)
     ; # clone related charm
     ; rm -rf {env:LOCAL_CHARM_DIR}
     ; git clone --branch {env:CHARM_BRANCH} {env:CHARM_REPO} {env:LOCAL_CHARM_DIR}


### PR DESCRIPTION
closes: https://github.com/canonical/pipelines-rocks/issues/85

I have compared this file  https://github.com/kubeflow/pipelines/blob/2.0.5/backend/Dockerfile.scheduledworkflow for tags [2.0.5](https://github.com/kubeflow/pipelines/blob/2.0.5/backend/Dockerfile.scheduledworkflow) and [2.2.0](https://github.com/kubeflow/pipelines/blob/2.2.0/backend/Dockerfile.scheduledworkflow). Changes: 
- Go bump 
- new env variables

Other changes:
- rewritten  the `rockcraft.yaml` based on up to date process 
- added tests for sanity

For experiment I tried to run the integration test for the rock but the bundle test is [failing to build charms](https://github.com/canonical/pipelines-rocks/actions/runs/9269011939/job/25501498014#step:9:562).