### PR TITLE
Update viewer-crd-controller to 2.2.0

### DIFF
--- a/viewer-crd-controller/rockcraft.yaml
+++ b/viewer-crd-controller/rockcraft.yaml
@@ -34,11 +34,12 @@ parts:
     build-environment:
       - CGO_ENABLED: 0
       - GOOS: linux
+      - GO111MODULE: "on"
     override-build: |
       mkdir -p $CRAFT_PART_INSTALL/bin
       mkdir -p $CRAFT_PART_INSTALL/third_party
 
-      GO111MODULE=on go build -o $CRAFT_PART_INSTALL/bin/controller backend/src/crd/controller/viewer/*.go
+      go build -o $CRAFT_PART_INSTALL/bin/controller backend/src/crd/controller/viewer/*.go
       ./hack/install-go-licenses.sh
       $GOBIN/go-licenses check ./backend/src/crd/controller/viewer
       $GOBIN/go-licenses csv ./backend/src/crd/controller/viewer > $CRAFT_PART_INSTALL/third_party/licenses.csv

--- a/viewer-crd-controller/rockcraft.yaml
+++ b/viewer-crd-controller/rockcraft.yaml
@@ -34,12 +34,11 @@ parts:
     build-environment:
       - CGO_ENABLED: 0
       - GOOS: linux
-      - GO111MODULE: on
     override-build: |
       mkdir -p $CRAFT_PART_INSTALL/bin
       mkdir -p $CRAFT_PART_INSTALL/third_party
 
-      go build -o $CRAFT_PART_INSTALL/bin/controller backend/src/crd/controller/viewer/*.go
+      GO111MODULE=on go build -o $CRAFT_PART_INSTALL/bin/controller backend/src/crd/controller/viewer/*.go
       ./hack/install-go-licenses.sh
       $GOBIN/go-licenses check ./backend/src/crd/controller/viewer
       $GOBIN/go-licenses csv ./backend/src/crd/controller/viewer > $CRAFT_PART_INSTALL/third_party/licenses.csv

--- a/viewer-crd-controller/rockcraft.yaml
+++ b/viewer-crd-controller/rockcraft.yaml
@@ -1,4 +1,4 @@
-# Based on: https://github.com/kubeflow/pipelines/blob/2.0.5/backend/Dockerfile.viewercontroller
+# Based on: https://github.com/kubeflow/pipelines/blob/2.2.0/backend/Dockerfile.viewercontroller
 name: viewer-crd-controller
 summary: An image for the Viewer CRD Controller
 description: |
@@ -34,11 +34,12 @@ parts:
     build-environment:
       - CGO_ENABLED: 0
       - GOOS: linux
+      - GO111MODULE: on
     override-build: |
       mkdir -p $CRAFT_PART_INSTALL/bin
       mkdir -p $CRAFT_PART_INSTALL/third_party
 
-      GO111MODULE=on go build -o $CRAFT_PART_INSTALL/bin/controller backend/src/crd/controller/viewer/*.go
+      go build -o $CRAFT_PART_INSTALL/bin/controller backend/src/crd/controller/viewer/*.go
       ./hack/install-go-licenses.sh
       $GOBIN/go-licenses check ./backend/src/crd/controller/viewer
       $GOBIN/go-licenses csv ./backend/src/crd/controller/viewer > $CRAFT_PART_INSTALL/third_party/licenses.csv

--- a/viewer-crd-controller/rockcraft.yaml
+++ b/viewer-crd-controller/rockcraft.yaml
@@ -1,30 +1,32 @@
-# Dockerfile: https://github.com/kubeflow/pipelines/blob/2.0.5/backend/Dockerfile.viewercontroller
+# Based on: https://github.com/kubeflow/pipelines/blob/2.0.5/backend/Dockerfile.viewercontroller
 name: viewer-crd-controller
 summary: An image for the Viewer CRD Controller
 description: |
   This image is used as part of the Charmed Kubeflow product.
-version: 2.0.5
+version: "2.2.0"
 license: Apache-2.0
 base: ubuntu@22.04
-build-base: ubuntu@22.04
+platforms:
+  amd64:
 run-user: _daemon_
 services:
   controller:
     override: replace
     summary: "viewer CRD controller"
     startup: enabled
-    command: controller
-platforms:
-  amd64:
+    environment:
+      MAX_NUM_VIEWERS: "50"
+      NAMESPACE: "kubeflow"
+    command: bash -c '/bin/controller --logtostderr=true --max_num_viewers=${MAX_NUM_VIEWERS} --namespace=${NAMESPACE}'
 
 parts:
   viewer-crd-controller:
     plugin: go
     source: https://github.com/kubeflow/pipelines
     build-snaps:
-      - go/1.20/stable
+      - go/1.21/stable
     source-type: git
-    source-tag: 2.0.5
+    source-tag: 2.2.0
     build-packages:
       - git
       - gcc
@@ -36,8 +38,7 @@ parts:
       mkdir -p $CRAFT_PART_INSTALL/bin
       mkdir -p $CRAFT_PART_INSTALL/third_party
 
-      go build -o $CRAFT_PART_INSTALL/bin/controller backend/src/crd/controller/viewer/*.go
-
+      GO111MODULE=on go build -o $CRAFT_PART_INSTALL/bin/controller backend/src/crd/controller/viewer/*.go
       ./hack/install-go-licenses.sh
       $GOBIN/go-licenses check ./backend/src/crd/controller/viewer
       $GOBIN/go-licenses csv ./backend/src/crd/controller/viewer > $CRAFT_PART_INSTALL/third_party/licenses.csv

--- a/viewer-crd-controller/tests/test_rock.py
+++ b/viewer-crd-controller/tests/test_rock.py
@@ -16,10 +16,7 @@ def rock_test_env(tmpdir):
     )
     yield tmpdir, container_name
 
-    try:
-        subprocess.run(["docker", "rm", container_name])
-    except Exception:
-        pass
+    subprocess.run(["docker", "rm", container_name], shell=True, check=False)
     # tmpdir fixture we use here should clean up the other files for us
 
 

--- a/viewer-crd-controller/tests/test_rock.py
+++ b/viewer-crd-controller/tests/test_rock.py
@@ -1,0 +1,59 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+import random
+import pytest
+import string
+import subprocess
+
+from charmed_kubeflow_chisme.rock import CheckRock
+
+
+@pytest.fixture()
+def rock_test_env(tmpdir):
+    """Yields a temporary directory and random docker container name, then cleans them up after."""
+    container_name = "".join(
+        [str(i) for i in random.choices(string.ascii_lowercase, k=8)]
+    )
+    yield tmpdir, container_name
+
+    try:
+        subprocess.run(["docker", "rm", container_name])
+    except Exception:
+        pass
+    # tmpdir fixture we use here should clean up the other files for us
+
+
+@pytest.mark.abort_on_fail
+def test_rock(rock_test_env):
+    """Test rock."""
+    temp_dir, container_name = rock_test_env
+    check_rock = CheckRock("rockcraft.yaml")
+    rock_image = check_rock.get_name()
+    rock_version = check_rock.get_version()
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
+
+    # assert we have the expected files
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /bin/controller",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /third_party",
+        ],
+        check=True,
+    )

--- a/viewer-crd-controller/tox.ini
+++ b/viewer-crd-controller/tox.ini
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 [tox]
 skipsdist = True
@@ -38,11 +38,12 @@ commands =
 
 [testenv:sanity]
 passenv = *
-allowlist_externals =
-    echo
+deps =
+    pytest
+    charmed-kubeflow-chisme
 commands =
-    # TODO: Implement sanity tests
-    echo "WARNING: This is a placeholder test - no test is implemented here."
+    # run rock tests
+    pytest -s -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
 
 [testenv:integration]
 passenv = *


### PR DESCRIPTION
closes: https://github.com/canonical/pipelines-rocks/issues/86

I have compared this file  https://github.com/kubeflow/pipelines/blob/2.0.5/backend/Dockerfile.viewercontroller
 for tags [2.0.5](https://github.com/kubeflow/pipelines/blob/2.0.5/backend/Dockerfile.viewercontroller) and [2.2.0](https://github.com/kubeflow/pipelines/blob/2.2.0/backend/Dockerfile.viewercontroller). Changes: 
- Go bump 

Other changes:
- rewritten  the `rockcraft.yaml` based on up to date process (I changed the way we build it plus I added two envs which we were skipping so far)
- added tests for sanity

For experiment I tried to run the integration test for the rock but the bundle test is [failing to build charms](https://github.com/canonical/pipelines-rocks/actions/runs/9269011939/job/25501498014#step:9:562).