### PR TITLE
Update visualisation server to v2.2.0

### DIFF
--- a/visualization-server/rockcraft.yaml
+++ b/visualization-server/rockcraft.yaml
@@ -1,20 +1,21 @@
-# Dockerfile: https://github.com/kubeflow/pipelines/blob/2.0.5/backend/Dockerfile.visualization
+# Based on: https://github.com/kubeflow/pipelines/blob/2.2.0/backend/Dockerfile.visualization
 name: visualization-server
-base: ubuntu@20.04
-version: '2.0.5'
 summary: ml-pipeline/visualization-server
 description: |
     ml-pipeline/visualization-server
     https://github.com/kubeflow/pipelines/tree/master/backend
-license: GPL-3.0
+version: "2.2.0"
+license: Apache-2.0
+base: ubuntu@22.04
 platforms:
     amd64:
 run-user: _daemon_
 services:
   vis-server:
     override: replace
-    command: python3.8 /server.py
+    summary: "visualization server service"
     startup: enabled
+    command: "python3 /server.py"
 
 package-repositories:
   - type: apt
@@ -22,20 +23,37 @@ package-repositories:
     priority: always
 
 parts:
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+      dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
+      > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+
   python:
     plugin: python
     source: https://github.com/kubeflow/pipelines.git
     source-subdir: backend/src/apiserver/visualization
-    source-tag: 2.0.5
+    source-tag: 2.2.0
     stage-packages:
       # sync this python version to that in the tensorflow 
       # base image of Dockerfile.visualization.  Also keep this
       # in sync with PARTS_PYTHON_INTERPRETER below
     - python3.8-venv
+    - python3.8-dev
     python-requirements:
     - requirements.txt
     build-environment: 
     - PARTS_PYTHON_INTERPRETER: python3.8
+  
+  python3-is-python3.8:
+    plugin: nil
+    override-build: |
+      # Ensure `python3` is an executable command in our primed image by making
+      # a symbolic link
+      mkdir -p $CRAFT_PART_INSTALL/usr/bin/
+      ln -s /usr/bin/python3.8 $CRAFT_PART_INSTALL/usr/bin/python3
 
   gcloud:
     plugin: nil
@@ -50,11 +68,10 @@ parts:
       mkdir -p "${CRAFT_PART_INSTALL}"/usr/local/gcloud
       tar -C "${CRAFT_PART_INSTALL}"/usr/local/gcloud -xf /tmp/google-cloud-sdk.tar.gz
       "${CRAFT_PART_INSTALL}"/usr/local/gcloud/google-cloud-sdk/install.sh
-      cp backend/src/apiserver/visualization/server.py $CRAFT_PART_INSTALL
 
   files:
     plugin: nil
     source: https://github.com/kubeflow/pipelines.git
-    source-tag: 2.0.5
+    source-tag: 2.2.0
     override-build: |
       cp -r backend/src/apiserver/visualization/* $CRAFT_PART_INSTALL

--- a/visualization-server/tests/test_rock.py
+++ b/visualization-server/tests/test_rock.py
@@ -56,7 +56,7 @@ def test_rock(rock_test_env):
             "/bin/bash",
             LOCAL_ROCK_IMAGE,
             "-c",
-            "pip list | grep tensorflows || { echo 'TensorFlow is not installed'; exit 1; }",
+            "pip list | grep tensorflow || { echo 'TensorFlow is not installed'; exit 1; }",
         ],
         check=True,
     )

--- a/visualization-server/tests/test_rock.py
+++ b/visualization-server/tests/test_rock.py
@@ -1,0 +1,62 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import random
+import pytest
+import string
+import subprocess
+
+from charmed_kubeflow_chisme.rock import CheckRock
+
+
+@pytest.fixture()
+def rock_test_env(tmpdir):
+    """Yields a temporary directory and random docker container name, then cleans them up after."""
+    container_name = "".join(
+        [str(i) for i in random.choices(string.ascii_lowercase, k=8)]
+    )
+    yield tmpdir, container_name
+
+    try:
+        subprocess.run(["docker", "rm", container_name])
+    except Exception:
+        pass
+    # tmpdir fixture we use here should clean up the other files for us
+
+
+@pytest.mark.abort_on_fail
+def test_rock(rock_test_env):
+    """Test rock."""
+    temp_dir, container_name = rock_test_env
+    check_rock = CheckRock("rockcraft.yaml")
+    rock_image = check_rock.get_name()
+    rock_version = check_rock.get_version()
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
+
+    # assert we have the expected files
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /server.py",
+        ],
+        check=True,
+    )
+
+    # assert tensorflow is properly installed
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "pip list | grep tensorflows || { echo 'TensorFlow is not installed'; exit 1; }",
+        ],
+        check=True,
+    )

--- a/visualization-server/tox.ini
+++ b/visualization-server/tox.ini
@@ -38,26 +38,19 @@ commands =
 
 [testenv:sanity]
 passenv = *
-allowlist_externals = 
-    echo
+deps =
+    pytest
+    charmed-kubeflow-chisme
 commands =
-    # TODO: Implement sanity tests
-    echo "WARNING: This is a placeholder test - no test is implemented here."
+    # run rock tests
+    pytest -s -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
 
 [testenv:integration]
 passenv = *
 allowlist_externals =
     echo
-    bash
-    git
-    rm
-    tox
-deps =
-    juju<4.0
-    pytest
-    pytest-operator
-    ops
 commands =
+    # TODO: Implement integration tests here
     echo "WARNING: This is a placeholder test - no test is implemented here."
     # Below is commented out due to https://github.com/canonical/pipelines-rocks/issues/61
     # we should remove above line and uncomment the below, once this is fixed.


### PR DESCRIPTION
Closes: https://github.com/canonical/pipelines-rocks/issues/87

I have compared tags `2.0.5` and `2.2.0` for this file https://github.com/kubeflow/pipelines/blob/2.2.0/backend/Dockerfile.visualization and there were no changes. 

Changes:
- I have cleaned up the structure of the `rockcraft.yaml` to be the same as in other ROCKs. 
- I have changed the base os to 22.04 (because of this there are some changes as 3.8 is not default python)
- I have added security team requirement 
- I have added sanity tests 

**Note:** when you build the ROCK and and run it locally with docker the server does not have any output. The only way to test if the rock is really working is to ssh to running rock and inspect the  processes (you can also just ssh to running ROCK and try to rrun it again from inside, if the rock is working the second run will tell you that other process is already running).