### PR TITLE
Update metadata writer to v2.2.0

### DIFF
--- a/metadata-writer/rockcraft.yaml
+++ b/metadata-writer/rockcraft.yaml
@@ -1,9 +1,9 @@
-# Dockerfile: https://github.com/kubeflow/pipelines/blob/2.0.5/backend/metadata_writer/Dockerfile
+# Based on: https://github.com/kubeflow/pipelines/blob/2.2.0/backend/metadata_writer/Dockerfile
 name: metadata-writer
 summary: Reusable end-to-end ML workflows built using the Kubeflow Pipelines SDK
 description: |
   This service logs the metadata for KFP components and pipelines.
-version: 2.0.5
+version: "2.2.0"
 license: Apache-2.0
 base: ubuntu@22.04
 run-user: _daemon_
@@ -11,8 +11,8 @@ services:
   controller:
     override: replace
     summary: "Entry point for kfp-metadata-writer oci-image"
-    command: python3 -u /kfp/metadata_writer/metadata_writer.py
     startup: enabled
+    command: "python3 -u /kfp/metadata_writer/metadata_writer.py"
 platforms:
   amd64:
 
@@ -22,11 +22,19 @@ package-repositories:
     priority: always
 
 parts:
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+      dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
+      > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+
   python:
     plugin: python
     source: https://github.com/kubeflow/pipelines.git
     source-subdir: backend/metadata_writer
-    source-tag: 2.0.5
+    source-tag: 2.2.0
     stage-packages:
       # sync this python version to the base image in the Dockerfile.
       # Also keep this in sync with PARTS_PYTHON_INTERPRETER below.
@@ -47,13 +55,7 @@ parts:
   copy-files:
     plugin: nil
     source: https://github.com/kubeflow/pipelines.git
-    source-tag: 2.0.5
+    source-tag: 2.2.0
     override-build: |
       mkdir -p ${CRAFT_PART_INSTALL}/kfp/metadata_writer/
       cp  ${CRAFT_PART_SRC}/backend/metadata_writer/src/* ${CRAFT_PART_INSTALL}/kfp/metadata_writer
-
-  security-team-requirement:
-    plugin: nil
-    override-build: |
-      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
-      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query


### PR DESCRIPTION
Closes: https://github.com/canonical/pipelines-rocks/issues/83

I have compared tags `2.0.5` and `2.2.0` for this file https://github.com/kubeflow/pipelines/blob/2.2.0/backend/metadata_writer/Dockerfile and there were no changes. 

Changes:
- I have cleaned up the structure of the `rockcraft.yaml` to be the same as in other ROCKs. 