### PR TITLE
Upgrade visualisation server ROCK to 2.3.0

### DIFF
--- a/visualization-server/rockcraft.yaml
+++ b/visualization-server/rockcraft.yaml
@@ -1,10 +1,10 @@
-# Based on: https://github.com/kubeflow/pipelines/blob/2.2.0/backend/Dockerfile.visualization
+# Based on: https://github.com/kubeflow/pipelines/blob/2.3.0/backend/Dockerfile.visualization
 name: visualization-server
 summary: ml-pipeline/visualization-server
 description: |
     ml-pipeline/visualization-server
     https://github.com/kubeflow/pipelines/tree/master/backend
-version: "2.2.0"
+version: "2.3.0"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:
@@ -35,7 +35,7 @@ parts:
     plugin: python
     source: https://github.com/kubeflow/pipelines.git
     source-subdir: backend/src/apiserver/visualization
-    source-tag: 2.2.0
+    source-tag: 2.3.0
     stage-packages:
       # sync this python version to that in the tensorflow 
       # base image of Dockerfile.visualization.  Also keep this
@@ -72,6 +72,6 @@ parts:
   files:
     plugin: nil
     source: https://github.com/kubeflow/pipelines.git
-    source-tag: 2.2.0
+    source-tag: 2.3.0
     override-build: |
       cp -r backend/src/apiserver/visualization/* $CRAFT_PART_INSTALL


### PR DESCRIPTION
Closes: https://github.com/canonical/pipelines-rocks/issues/140

No changes in code the Docker image did not change 
https://github.com/kubeflow/pipelines/blob/2.2.0/backend/Dockerfile.visualization
https://github.com/kubeflow/pipelines/blob/2.3.0/backend/Dockerfile.visualization

I have bumped the tags.

**Steps for local comparison test**

```
# build the ROCK
rockcraft clean && rockcraft pack --verbosity=trace
sudo rockcraft.skopeo --insecure-policy copy oci-archive:visualization-server_2.3.0_amd64.rock docker-daemon:visualization-server:2.3.0

# Upstream image 
docker run gcr.io/ml-pipeline/visualization-server:2.3.0

########################################################

# Rock 
docker run visualization-server:2.3.0

# Output
2024-11-14T09:50:45.048Z [pebble] Started daemon.
2024-11-14T09:50:45.082Z [pebble] POST /v1/services 16.662624ms 202
2024-11-14T09:50:45.100Z [pebble] Service "controller" starting: bash -c '/bin/controller --logtostderr=true --max_num_viewers=${MAX_NUM_VIEWERS} --namespace=${NAMESPACE}'
2024-11-14T09:50:45.159Z [pebble] Change 1 task (Start service "controller") failed: cannot start service: exited quickly with code 1
2024-11-14T09:50:45.175Z [pebble] GET /v1/changes/1/wait 91.71935ms 200
2024-11-14T09:50:45.175Z [pebble] Started default services with change 1.

# Output for service is hidden you need to get the id of running docker container 
docker ps
# bash into the container 
docker exec -ti <your_id> bash
# execute the service command manually
$ /bin/controller
```
