### PR TITLE
chore: upgrade `api-server` Rock to 2.3.0

### DIFF
--- a/api-server/rockcraft.yaml
+++ b/api-server/rockcraft.yaml
@@ -17,7 +17,9 @@ services:
       LOG_LEVEL: "info"
     command: /bin/apiserver --config=/config --sampleconfig=/config/sample_config.json -logtostderr=true --logLevel=$LOG_LEVEL
 
-
+# Adds Deadsnakes ppa package repo to install python3.8 interpreter
+# Required when using a python version different from the default in the base
+# Ref: https://documentation.ubuntu.com/rockcraft/en/latest/reference/plugins/python_plugin/#dependencies
 package-repositories:
   - type: apt
     ppa: deadsnakes/ppa

--- a/api-server/rockcraft.yaml
+++ b/api-server/rockcraft.yaml
@@ -1,9 +1,9 @@
-# Dockerfile: https://github.com/kubeflow/pipelines/blob/2.2.0/backend/Dockerfile
+# Dockerfile: https://github.com/kubeflow/pipelines/blob/2.3.0/backend/Dockerfile
 name: api-server
 summary: An image for using Kubeflow pipelines API
 description: An image for using Kubeflow pipelines API
-version: "2.2.0"
-base: ubuntu@20.04
+version: "2.3.0"
+base: ubuntu@22.04
 license: Apache-2.0
 platforms:
   amd64:
@@ -19,7 +19,6 @@ services:
 
 
 package-repositories:
-  # Required for build-packages=python3.7
   - type: apt
     ppa: deadsnakes/ppa
     priority: always
@@ -34,7 +33,7 @@ parts:
   builder:
     plugin: go
     source: https://github.com/kubeflow/pipelines.git
-    source-tag: 2.2.0
+    source-tag: 2.3.0
     build-snaps:
       - go/1.21/stable
     build-environment:
@@ -58,15 +57,15 @@ parts:
   compiler:
     plugin: nil
     source: https://github.com/kubeflow/pipelines.git
-    source-tag: 2.2.0
+    source-tag: 2.3.0
     build-environment:
-      - ARGO_VERSION: v3.4.16
+      - ARGO_VERSION: v3.4.17
     build-packages:
       - default-jdk
-      - python3.7
+      - python3.8
       # required to build google-cloud-profiler wheel for pyproject.toml-based projects
-      - python3.7-dev
-      - python3.7-distutils
+      - python3.8-dev
+      - python3.8-distutils
       - jq
       - wget
 
@@ -77,12 +76,11 @@ parts:
       rm -rf ./*
 
       # Create a symbolic link so the rest of this script is like upstream
-      ln -s /usr/bin/python3.7 python3
+      ln -s /usr/bin/python3.8 python3
       PATH=.:$PATH
 
       # Setup pip
-      # This is required because the stage environment uses Python3.7. Do not update unless the upstream Dockerfile does.
-      wget https://bootstrap.pypa.io/pip/3.7/get-pip.py && python3 get-pip.py
+      wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py
 
       cp $CRAFT_PART_SRC/backend/requirements.txt .
       python3 -m pip install -r requirements.txt --no-cache-dir
@@ -111,7 +109,7 @@ parts:
     after: [builder, compiler]
     plugin: nil
     source: https://github.com/kubeflow/pipelines.git
-    source-tag: 2.2.0
+    source-tag: 2.3.0
     build-packages:
       - ca-certificates
       - wget

--- a/api-server/tests/test_rock.py
+++ b/api-server/tests/test_rock.py
@@ -1,0 +1,44 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+import pytest
+import subprocess
+
+from charmed_kubeflow_chisme.rock import CheckRock
+
+
+@pytest.mark.abort_on_fail
+def test_rock():
+    """Test rock."""
+    check_rock = CheckRock("rockcraft.yaml")
+    rock_image = check_rock.get_name()
+    rock_version = check_rock.get_version()
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
+
+    # assert the rock contains the expected files
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /bin/apiserver",
+        ],
+        check=True,
+    )
+
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /samples",
+        ],
+        check=True,
+    )

--- a/api-server/tox.ini
+++ b/api-server/tox.ini
@@ -39,11 +39,12 @@ commands =
 
 [testenv:sanity]
 passenv = *
-allowlist_externals = 
-    echo
+deps =
+    pytest
+    charmed-kubeflow-chisme
 commands =
-    # TODO: Implement sanity tests
-    echo "WARNING: This is a placeholder test - no test is implemented here."
+    # run rock tests
+    pytest -s -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
 
 [testenv:integration]
 passenv = *


### PR DESCRIPTION
Closes #135 

## Summary
* upgrades Rock version to `2.3.0`, changes from [Dockerfile](https://github.com/kubeflow/pipelines/blob/2.3.0/backend/Dockerfile):
  * bump python version to `3.8`
  *  bump `ARGO_VERSION` to `v3.4.17`
* adds sanity tests to the rockcraft project

## Testing
1. Download the Rock artifact from the PR Checks [Summary](https://github.com/canonical/pipelines-rocks/actions/runs/11896323458)
2. Import the rock into your local docker registry using `skopeo`:
```
rockcraft.skopeo --insecure-policy copy oci-archive:api-server docker-daemon:api-server:test-rock
```
3. Run the Rock with the service command
```
LOG_LEVEL=info
docker run api-server:test-rock exec /bin/apiserver --config=/config --sampleconfig=/config/sample_config.json -logtostderr=true --logLevel=$LOG_LEVEL
```
4. Run the upstream image
```
docker run gcr.io/ml-pipeline/api-server:2.3.0
```
Compare the Rock and upstream image outputs, they should be the same except for the paths in the logs

<details>
<summary>Expected output (after a few minutes)</summary>
I1118 16:16:38.591426      15 client_manager.go:170] Initializing client manager
I1118 16:16:38.591467      15 client_manager.go:171] Initializing DB client...
I1118 16:16:38.591497      15 config.go:57] Config DBConfig.MySQLConfig.ExtraParams not specified, skipping
F1118 16:23:02.974342      15 error.go:425] dial tcp: lookup mysql on 10.200.200.246:53: no such host

goroutine 1 [running]:
github.com/golang/glog.Fatalf(...)
	/root/go/pkg/mod/github.com/golang/glog@v1.2.0/glog.go:690
github.com/kubeflow/pipelines/backend/src/common/util.TerminateIfError({0x2fed860, 0xc0008cc0a0})
	/root/parts/builder/build/backend/src/common/util/error.go:425 +0x98
github.com/kubeflow/pipelines/backend/src/apiserver/client_manager.initDBDriver({0xc00053f398, 0x5}, 0x53d1ac1000)
	/root/parts/builder/build/backend/src/apiserver/client_manager/client_manager.go:448 +0x5c7
github.com/kubeflow/pipelines/backend/src/apiserver/client_manager.InitDBClient(0x29b072c?)
	/root/parts/builder/build/backend/src/apiserver/client_manager/client_manager.go:228 +0x6b
github.com/kubeflow/pipelines/backend/src/apiserver/client_manager.(*ClientManager).init(0xc000affe00)
	/root/parts/builder/build/backend/src/apiserver/client_manager/client_manager.go:172 +0xa5
github.com/kubeflow/pipelines/backend/src/apiserver/client_manager.NewClientManager(...)
	/root/parts/builder/build/backend/src/apiserver/client_manager/client_manager.go:530
main.main()
	/root/parts/builder/build/backend/src/apiserver/main.go:81 +0x165

SIGABRT: abort
PC=0x409a8e m=5 sigcode=18446744073709551610

goroutine 1 [running, locked to thread]:
runtime/internal/syscall.Syscall6()
	/snap/go/10678/src/runtime/internal/syscall/asm_linux_amd64.s:36 +0xe fp=0xc000aff560 sp=0xc000aff558 pc=0x409a8e
syscall.RawSyscall6(0x4af?, 0xc0007cf000?, 0x9?, 0x100?, 0xc0007ce351?, 0xc000aff5e8?, 0x54fbe5?)
	/snap/go/10678/src/runtime/internal/syscall/syscall_linux.go:38 +0xd fp=0xc000aff5a8 sp=0xc000aff560 pc=0x409a6d
syscall.RawSyscall(0x54fb6e?, 0x0?, 0x0?, 0xc6f859ba134795?)
	/snap/go/10678/src/syscall/syscall_linux.go:62 +0x15 fp=0xc000aff5f0 sp=0xc000aff5a8 pc=0x4893f5
syscall.Tgkill(0xba?, 0x0?, 0x0?)
	/snap/go/10678/src/syscall/zsyscall_linux_amd64.go:879 +0x25 fp=0xc000aff620 sp=0xc000aff5f0 pc=0x487345
github.com/golang/glog.abortProcess()
	/root/go/pkg/mod/github.com/golang/glog@v1.2.0/glog_file_linux.go:35 +0x87 fp=0xc000aff668 sp=0xc000aff620 pc=0x54fca7
github.com/golang/glog.ctxfatalf({0x0?, 0x0?}, 0x2fed860?, {0x298b23e?, 0xc000818de0?}, {0xc0007f8050?, 0x0?, 0x0?})
	/root/go/pkg/mod/github.com/golang/glog@v1.2.0/glog.go:647 +0x6a fp=0xc000aff6d0 sp=0xc000aff668 pc=0x54dc0a
github.com/golang/glog.fatalf(...)
	/root/go/pkg/mod/github.com/golang/glog@v1.2.0/glog.go:657
github.com/golang/glog.Fatalf(...)
	/root/go/pkg/mod/github.com/golang/glog@v1.2.0/glog.go:690
github.com/kubeflow/pipelines/backend/src/common/util.TerminateIfError({0x2fed860, 0xc0008cc0a0})
	/root/parts/builder/build/backend/src/common/util/error.go:425 +0x98 fp=0xc000aff720 sp=0xc000aff6d0 pc=0x1b23898
github.com/kubeflow/pipelines/backend/src/apiserver/client_manager.initDBDriver({0xc00053f398, 0x5}, 0x53d1ac1000)
	/root/parts/builder/build/backend/src/apiserver/client_manager/client_manager.go:448 +0x5c7 fp=0xc000aff8d0 sp=0xc000aff720 pc=0x1d12747
github.com/kubeflow/pipelines/backend/src/apiserver/client_manager.InitDBClient(0x29b072c?)
	/root/parts/builder/build/backend/src/apiserver/client_manager/client_manager.go:228 +0x6b fp=0xc000affb48 sp=0xc000aff8d0 pc=0x1d105ab
github.com/kubeflow/pipelines/backend/src/apiserver/client_manager.(*ClientManager).init(0xc000affe00)
	/root/parts/builder/build/backend/src/apiserver/client_manager/client_manager.go:172 +0xa5 fp=0xc000affc48 sp=0xc000affb48 pc=0x1d0fa45
github.com/kubeflow/pipelines/backend/src/apiserver/client_manager.NewClientManager(...)
	/root/parts/builder/build/backend/src/apiserver/client_manager/client_manager.go:530
main.main()
	/root/parts/builder/build/backend/src/apiserver/main.go:81 +0x165 fp=0xc000afff40 sp=0xc000affc48 pc=0x21b9465
runtime.main()
	/snap/go/10678/src/runtime/proc.go:267 +0x2bb fp=0xc000afffe0 sp=0xc000afff40 pc=0x4418bb
runtime.goexit()
	/snap/go/10678/src/runtime/asm_amd64.s:1650 +0x1 fp=0xc000afffe8 sp=0xc000afffe0 pc=0x471e81

goroutine 2 [force gc (idle), 2 minutes]:
runtime.gopark(0x67598b3ed059?, 0x0?, 0x0?, 0x0?, 0x0?)
	/snap/go/10678/src/runtime/proc.go:398 +0xce fp=0xc000084fa8 sp=0xc000084f88 pc=0x441d2e
runtime.goparkunlock(...)
	/snap/go/10678/src/runtime/proc.go:404
runtime.forcegchelper()
	/snap/go/10678/src/runtime/proc.go:322 +0xb3 fp=0xc000084fe0 sp=0xc000084fa8 pc=0x441b93
runtime.goexit()
	/snap/go/10678/src/runtime/asm_amd64.s:1650 +0x1 fp=0xc000084fe8 sp=0xc000084fe0 pc=0x471e81
created by runtime.init.6 in goroutine 1
	/snap/go/10678/src/runtime/proc.go:310 +0x1a

goroutine 3 [GC sweep wait]:
runtime.gopark(0x1?, 0x0?, 0x0?, 0x0?, 0x0?)
	/snap/go/10678/src/runtime/proc.go:398 +0xce fp=0xc000085778 sp=0xc000085758 pc=0x441d2e
runtime.goparkunlock(...)
	/snap/go/10678/src/runtime/proc.go:404
runtime.bgsweep(0x0?)
	/snap/go/10678/src/runtime/mgcsweep.go:321 +0xdf fp=0xc0000857c8 sp=0xc000085778 pc=0x42bc7f
runtime.gcenable.func1()
	/snap/go/10678/src/runtime/mgc.go:200 +0x25 fp=0xc0000857e0 sp=0xc0000857c8 pc=0x420dc5
runtime.goexit()
	/snap/go/10678/src/runtime/asm_amd64.s:1650 +0x1 fp=0xc0000857e8 sp=0xc0000857e0 pc=0x471e81
created by runtime.gcenable in goroutine 1
	/snap/go/10678/src/runtime/mgc.go:200 +0x66

goroutine 4 [GC scavenge wait]:
runtime.gopark(0x3ba80203?, 0x3b9aca00?, 0x0?, 0x0?, 0x0?)
	/snap/go/10678/src/runtime/proc.go:398 +0xce fp=0xc000085f70 sp=0xc000085f50 pc=0x441d2e
runtime.goparkunlock(...)
	/snap/go/10678/src/runtime/proc.go:404
runtime.(*scavengerState).park(0x46e7ca0)
	/snap/go/10678/src/runtime/mgcscavenge.go:425 +0x49 fp=0xc000085fa0 sp=0xc000085f70 pc=0x4294e9
runtime.bgscavenge(0x0?)
	/snap/go/10678/src/runtime/mgcscavenge.go:658 +0x59 fp=0xc000085fc8 sp=0xc000085fa0 pc=0x429a99
runtime.gcenable.func2()
	/snap/go/10678/src/runtime/mgc.go:201 +0x25 fp=0xc000085fe0 sp=0xc000085fc8 pc=0x420d65
runtime.goexit()
	/snap/go/10678/src/runtime/asm_amd64.s:1650 +0x1 fp=0xc000085fe8 sp=0xc000085fe0 pc=0x471e81
created by runtime.gcenable in goroutine 1
	/snap/go/10678/src/runtime/mgc.go:201 +0xa5

goroutine 5 [finalizer wait, 6 minutes]:
runtime.gopark(0x198?, 0x297da00?, 0x1?, 0x2e?, 0x0?)
	/snap/go/10678/src/runtime/proc.go:398 +0xce fp=0xc000084620 sp=0xc000084600 pc=0x441d2e
runtime.runfinq()
	/snap/go/10678/src/runtime/mfinal.go:193 +0x107 fp=0xc0000847e0 sp=0xc000084620 pc=0x41fde7
runtime.goexit()
	/snap/go/10678/src/runtime/asm_amd64.s:1650 +0x1 fp=0xc0000847e8 sp=0xc0000847e0 pc=0x471e81
created by runtime.createfing in goroutine 1
	/snap/go/10678/src/runtime/mfinal.go:163 +0x3d

goroutine 6 [GC worker (idle), 6 minutes]:
runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
	/snap/go/10678/src/runtime/proc.go:398 +0xce fp=0xc000086750 sp=0xc000086730 pc=0x441d2e
runtime.gcBgMarkWorker()
	/snap/go/10678/src/runtime/mgc.go:1295 +0xe5 fp=0xc0000867e0 sp=0xc000086750 pc=0x422945
runtime.goexit()
	/snap/go/10678/src/runtime/asm_amd64.s:1650 +0x1 fp=0xc0000867e8 sp=0xc0000867e0 pc=0x471e81
created by runtime.gcBgMarkStartWorkers in goroutine 1
	/snap/go/10678/src/runtime/mgc.go:1219 +0x1c

goroutine 18 [GC worker (idle), 6 minutes]:
runtime.gopark(0x471b2e0?, 0x3?, 0x52?, 0x26?, 0x0?)
	/snap/go/10678/src/runtime/proc.go:398 +0xce fp=0xc000080750 sp=0xc000080730 pc=0x441d2e
runtime.gcBgMarkWorker()
	/snap/go/10678/src/runtime/mgc.go:1295 +0xe5 fp=0xc0000807e0 sp=0xc000080750 pc=0x422945
runtime.goexit()
	/snap/go/10678/src/runtime/asm_amd64.s:1650 +0x1 fp=0xc0000807e8 sp=0xc0000807e0 pc=0x471e81
created by runtime.gcBgMarkStartWorkers in goroutine 1
	/snap/go/10678/src/runtime/mgc.go:1219 +0x1c

goroutine 19 [GC worker (idle), 6 minutes]:
runtime.gopark(0x670136bdf794?, 0x3?, 0xc7?, 0xa8?, 0x0?)
	/snap/go/10678/src/runtime/proc.go:398 +0xce fp=0xc000080f50 sp=0xc000080f30 pc=0x441d2e
runtime.gcBgMarkWorker()
	/snap/go/10678/src/runtime/mgc.go:1295 +0xe5 fp=0xc000080fe0 sp=0xc000080f50 pc=0x422945
runtime.goexit()
	/snap/go/10678/src/runtime/asm_amd64.s:1650 +0x1 fp=0xc000080fe8 sp=0xc000080fe0 pc=0x471e81
created by runtime.gcBgMarkStartWorkers in goroutine 1
	/snap/go/10678/src/runtime/mgc.go:1219 +0x1c

goroutine 34 [GC worker (idle)]:
runtime.gopark(0x67598bd17fec?, 0x3?, 0x3d?, 0x2?, 0x0?)
	/snap/go/10678/src/runtime/proc.go:398 +0xce fp=0xc000506750 sp=0xc000506730 pc=0x441d2e
runtime.gcBgMarkWorker()
	/snap/go/10678/src/runtime/mgc.go:1295 +0xe5 fp=0xc0005067e0 sp=0xc000506750 pc=0x422945
runtime.goexit()
	/snap/go/10678/src/runtime/asm_amd64.s:1650 +0x1 fp=0xc0005067e8 sp=0xc0005067e0 pc=0x471e81
created by runtime.gcBgMarkStartWorkers in goroutine 1
	/snap/go/10678/src/runtime/mgc.go:1219 +0x1c

goroutine 35 [GC worker (idle), 6 minutes]:
runtime.gopark(0x670136be19fd?, 0x3?, 0xa6?, 0x3?, 0x0?)
	/snap/go/10678/src/runtime/proc.go:398 +0xce fp=0xc000506f50 sp=0xc000506f30 pc=0x441d2e
runtime.gcBgMarkWorker()
	/snap/go/10678/src/runtime/mgc.go:1295 +0xe5 fp=0xc000506fe0 sp=0xc000506f50 pc=0x422945
runtime.goexit()
	/snap/go/10678/src/runtime/asm_amd64.s:1650 +0x1 fp=0xc000506fe8 sp=0xc000506fe0 pc=0x471e81
created by runtime.gcBgMarkStartWorkers in goroutine 1
	/snap/go/10678/src/runtime/mgc.go:1219 +0x1c

goroutine 36 [GC worker (idle), 6 minutes]:
runtime.gopark(0x670136be00b4?, 0x3?, 0x88?, 0xc5?, 0x0?)
	/snap/go/10678/src/runtime/proc.go:398 +0xce fp=0xc000507750 sp=0xc000507730 pc=0x441d2e
runtime.gcBgMarkWorker()
	/snap/go/10678/src/runtime/mgc.go:1295 +0xe5 fp=0xc0005077e0 sp=0xc000507750 pc=0x422945
runtime.goexit()
	/snap/go/10678/src/runtime/asm_amd64.s:1650 +0x1 fp=0xc0005077e8 sp=0xc0005077e0 pc=0x471e81
created by runtime.gcBgMarkStartWorkers in goroutine 1
	/snap/go/10678/src/runtime/mgc.go:1219 +0x1c

goroutine 37 [GC worker (idle)]:
runtime.gopark(0x67598bd130ec?, 0x3?, 0xd3?, 0x11?, 0x0?)
	/snap/go/10678/src/runtime/proc.go:398 +0xce fp=0xc000507f50 sp=0xc000507f30 pc=0x441d2e
runtime.gcBgMarkWorker()
	/snap/go/10678/src/runtime/mgc.go:1295 +0xe5 fp=0xc000507fe0 sp=0xc000507f50 pc=0x422945
runtime.goexit()
	/snap/go/10678/src/runtime/asm_amd64.s:1650 +0x1 fp=0xc000507fe8 sp=0xc000507fe0 pc=0x471e81
created by runtime.gcBgMarkStartWorkers in goroutine 1
	/snap/go/10678/src/runtime/mgc.go:1219 +0x1c

goroutine 50 [GC worker (idle), 6 minutes]:
runtime.gopark(0x670136bdcf7e?, 0x1?, 0xa5?, 0xc9?, 0x0?)
	/snap/go/10678/src/runtime/proc.go:398 +0xce fp=0xc000502750 sp=0xc000502730 pc=0x441d2e
runtime.gcBgMarkWorker()
	/snap/go/10678/src/runtime/mgc.go:1295 +0xe5 fp=0xc0005027e0 sp=0xc000502750 pc=0x422945
runtime.goexit()
	/snap/go/10678/src/runtime/asm_amd64.s:1650 +0x1 fp=0xc0005027e8 sp=0xc0005027e0 pc=0x471e81
created by runtime.gcBgMarkStartWorkers in goroutine 1
	/snap/go/10678/src/runtime/mgc.go:1219 +0x1c

goroutine 7 [select, 2 minutes]:
runtime.gopark(0xc000504790?, 0x2?, 0xc8?, 0x89?, 0xc000504774?)
	/snap/go/10678/src/runtime/proc.go:398 +0xce fp=0xc000504618 sp=0xc0005045f8 pc=0x441d2e
runtime.selectgo(0xc000504790, 0xc000504770, 0x0?, 0x0, 0x0?, 0x1)
	/snap/go/10678/src/runtime/select.go:327 +0x725 fp=0xc000504738 sp=0xc000504618 pc=0x451925
github.com/golang/glog.(*fileSink).flushDaemon(0x46e4b98)
	/root/go/pkg/mod/github.com/golang/glog@v1.2.0/glog_file.go:351 +0xb9 fp=0xc0005047c8 sp=0xc000504738 pc=0x54f919
github.com/golang/glog.init.1.func1()
	/root/go/pkg/mod/github.com/golang/glog@v1.2.0/glog_file.go:166 +0x25 fp=0xc0005047e0 sp=0xc0005047c8 pc=0x54e9c5
runtime.goexit()
	/snap/go/10678/src/runtime/asm_amd64.s:1650 +0x1 fp=0xc0005047e8 sp=0xc0005047e0 pc=0x471e81
created by github.com/golang/glog.init.1 in goroutine 1
	/root/go/pkg/mod/github.com/golang/glog@v1.2.0/glog_file.go:166 +0x135

goroutine 8 [select]:
runtime.gopark(0xc000504f88?, 0x3?, 0x10?, 0x13?, 0xc000504f72?)
	/snap/go/10678/src/runtime/proc.go:398 +0xce fp=0xc000504e18 sp=0xc000504df8 pc=0x441d2e
runtime.selectgo(0xc000504f88, 0xc000504f6c, 0xc0009d0b80?, 0x0, 0x0?, 0x1)
	/snap/go/10678/src/runtime/select.go:327 +0x725 fp=0xc000504f38 sp=0xc000504e18 pc=0x451925
go.opencensus.io/stats/view.(*worker).start(0xc0009d0b80)
	/root/go/pkg/mod/go.opencensus.io@v0.24.0/stats/view/worker.go:292 +0x9f fp=0xc000504fc8 sp=0xc000504f38 pc=0x147871f
go.opencensus.io/stats/view.init.0.func1()
	/root/go/pkg/mod/go.opencensus.io@v0.24.0/stats/view/worker.go:34 +0x25 fp=0xc000504fe0 sp=0xc000504fc8 pc=0x1477a45
runtime.goexit()
	/snap/go/10678/src/runtime/asm_amd64.s:1650 +0x1 fp=0xc000504fe8 sp=0xc000504fe0 pc=0x471e81
created by go.opencensus.io/stats/view.init.0 in goroutine 1
	/root/go/pkg/mod/go.opencensus.io@v0.24.0/stats/view/worker.go:34 +0x8d

goroutine 10 [chan receive, 6 minutes]:
runtime.gopark(0xc000505728?, 0x40c3f7?, 0x20?, 0x81?, 0xc000505790?)
	/snap/go/10678/src/runtime/proc.go:398 +0xce fp=0xc0005056f8 sp=0xc0005056d8 pc=0x441d2e
runtime.chanrecv(0xc0000b4f60, 0xc0005057a8, 0x1)
	/snap/go/10678/src/runtime/chan.go:583 +0x3cd fp=0xc000505770 sp=0xc0005056f8 pc=0x40d50d
runtime.chanrecv1(0xc0005057d0?, 0x448e1c?)
	/snap/go/10678/src/runtime/chan.go:442 +0x12 fp=0xc000505798 sp=0xc000505770 pc=0x40d112
knative.dev/pkg/metrics.(*metricsWorker).start(0xc000932880)
	/root/go/pkg/mod/knative.dev/pkg@v0.0.0-20231011201526-df28feae6d34/metrics/metrics_worker.go:99 +0x29 fp=0xc0005057c8 sp=0xc000505798 pc=0x15bb689
knative.dev/pkg/metrics.init.0.func1()
	/root/go/pkg/mod/knative.dev/pkg@v0.0.0-20231011201526-df28feae6d34/metrics/exporter.go:39 +0x25 fp=0xc0005057e0 sp=0xc0005057c8 pc=0x15bb625
runtime.goexit()
	/snap/go/10678/src/runtime/asm_amd64.s:1650 +0x1 fp=0xc0005057e8 sp=0xc0005057e0 pc=0x471e81
created by knative.dev/pkg/metrics.init.0 in goroutine 1
	/root/go/pkg/mod/knative.dev/pkg@v0.0.0-20231011201526-df28feae6d34/metrics/exporter.go:39 +0xad

goroutine 111 [semacquire, 6 minutes]:
runtime.gopark(0xc0000061a0?, 0x5?, 0x80?, 0x81?, 0x452be5?)
	/snap/go/10678/src/runtime/proc.go:398 +0xce fp=0xc000502e28 sp=0xc000502e08 pc=0x441d2e
runtime.goparkunlock(...)
	/snap/go/10678/src/runtime/proc.go:404
runtime.semacquire1(0xc00053f5e8, 0x0?, 0x1, 0x0, 0xe0?)
	/snap/go/10678/src/runtime/sema.go:160 +0x218 fp=0xc000502e90 sp=0xc000502e28 pc=0x452958
sync.runtime_Semacquire(0x1bd5260?)
	/snap/go/10678/src/runtime/sema.go:62 +0x25 fp=0xc000502ec8 sp=0xc000502e90 pc=0x46dd65
sync.(*WaitGroup).Wait(0xc00053f5c0?)
	/snap/go/10678/src/sync/waitgroup.go:116 +0x48 fp=0xc000502ef0 sp=0xc000502ec8 pc=0x47e848
github.com/spf13/viper.(*Viper).WatchConfig.func1()
	/root/go/pkg/mod/github.com/spf13/viper@v1.15.0/viper.go:498 +0x345 fp=0xc000502fe0 sp=0xc000502ef0 pc=0x1c1d0a5
runtime.goexit()
	/snap/go/10678/src/runtime/asm_amd64.s:1650 +0x1 fp=0xc000502fe8 sp=0xc000502fe0 pc=0x471e81
created by github.com/spf13/viper.(*Viper).WatchConfig in goroutine 1
	/root/go/pkg/mod/github.com/spf13/viper@v1.15.0/viper.go:439 +0x87

goroutine 112 [IO wait, 6 minutes]:
runtime.gopark(0x0?, 0xb?, 0x0?, 0x0?, 0x3?)
	/snap/go/10678/src/runtime/proc.go:398 +0xce fp=0xc000b0fce0 sp=0xc000b0fcc0 pc=0x441d2e
runtime.netpollblock(0x487258?, 0x40a666?, 0x0?)
	/snap/go/10678/src/runtime/netpoll.go:564 +0xf7 fp=0xc000b0fd18 sp=0xc000b0fce0 pc=0x43a4d7
internal/poll.runtime_pollWait(0x783ca4a86710, 0x72)
	/snap/go/10678/src/runtime/netpoll.go:343 +0x85 fp=0xc000b0fd38 sp=0xc000b0fd18 pc=0x46c4e5
internal/poll.(*pollDesc).wait(0xc00001d8c0?, 0xc000b0fed0?, 0x1)
	/snap/go/10678/src/internal/poll/fd_poll_runtime.go:84 +0x27 fp=0xc000b0fd60 sp=0xc000b0fd38 pc=0x4e87a7
internal/poll.(*pollDesc).waitRead(...)
	/snap/go/10678/src/internal/poll/fd_poll_runtime.go:89
internal/poll.(*FD).Read(0xc00001d8c0, {0xc000b0fed0, 0x10000, 0x10000})
	/snap/go/10678/src/internal/poll/fd_unix.go:164 +0x27a fp=0xc000b0fdf8 sp=0xc000b0fd60 pc=0x4e9a9a
os.(*File).read(...)
	/snap/go/10678/src/os/file_posix.go:29
os.(*File).Read(0xc000932e60, {0xc000b0fed0?, 0x0?, 0x0?})
	/snap/go/10678/src/os/file.go:118 +0x52 fp=0xc000b0fe38 sp=0xc000b0fdf8 pc=0x4f5232
github.com/fsnotify/fsnotify.(*Watcher).readEvents(0xc000753f90)
	/root/go/pkg/mod/github.com/fsnotify/fsnotify@v1.6.0/backend_inotify.go:356 +0xd2 fp=0xc000b1ffc8 sp=0xc000b0fe38 pc=0x1bd5392
github.com/fsnotify/fsnotify.NewWatcher.func1()
	/root/go/pkg/mod/github.com/fsnotify/fsnotify@v1.6.0/backend_inotify.go:150 +0x25 fp=0xc000b1ffe0 sp=0xc000b1ffc8 pc=0x1bd4e05
runtime.goexit()
	/snap/go/10678/src/runtime/asm_amd64.s:1650 +0x1 fp=0xc000b1ffe8 sp=0xc000b1ffe0 pc=0x471e81
created by github.com/fsnotify/fsnotify.NewWatcher in goroutine 111
	/root/go/pkg/mod/github.com/fsnotify/fsnotify@v1.6.0/backend_inotify.go:150 +0x186

goroutine 113 [select, 6 minutes]:
runtime.gopark(0xc000503f80?, 0x2?, 0x0?, 0x0?, 0xc000503ef4?)
	/snap/go/10678/src/runtime/proc.go:398 +0xce fp=0xc000503d78 sp=0xc000503d58 pc=0x441d2e
runtime.selectgo(0xc000503f80, 0xc000503ef0, 0x0?, 0x0, 0x0?, 0x1)
	/snap/go/10678/src/runtime/select.go:327 +0x725 fp=0xc000503e98 sp=0xc000503d78 pc=0x451925
github.com/spf13/viper.(*Viper).WatchConfig.func1.1()
	/root/go/pkg/mod/github.com/spf13/viper@v1.15.0/viper.go:461 +0xfc fp=0xc000503fe0 sp=0xc000503e98 pc=0x1c1d1fc
runtime.goexit()
	/snap/go/10678/src/runtime/asm_amd64.s:1650 +0x1 fp=0xc000503fe8 sp=0xc000503fe0 pc=0x471e81
created by github.com/spf13/viper.(*Viper).WatchConfig.func1 in goroutine 111
	/root/go/pkg/mod/github.com/spf13/viper@v1.15.0/viper.go:459 +0x310

goroutine 130 [select, 6 minutes]:
runtime.gopark(0xc000505f88?, 0x2?, 0x0?, 0x0?, 0xc000505f84?)
	/snap/go/10678/src/runtime/proc.go:398 +0xce fp=0xc000505e30 sp=0xc000505e10 pc=0x441d2e
runtime.selectgo(0xc000505f88, 0xc000505f80, 0x0?, 0x0, 0x0?, 0x1)
	/snap/go/10678/src/runtime/select.go:327 +0x725 fp=0xc000505f50 sp=0xc000505e30 pc=0x451925
database/sql.(*DB).connectionOpener(0xc00062bee0, {0x301d360, 0xc000a84050})
	/snap/go/10678/src/database/sql/sql.go:1218 +0x87 fp=0xc000505fb8 sp=0xc000505f50 pc=0x1b00a47
database/sql.OpenDB.func1()
	/snap/go/10678/src/database/sql/sql.go:791 +0x28 fp=0xc000505fe0 sp=0xc000505fb8 pc=0x1afee68
runtime.goexit()
	/snap/go/10678/src/runtime/asm_amd64.s:1650 +0x1 fp=0xc000505fe8 sp=0xc000505fe0 pc=0x471e81
created by database/sql.OpenDB in goroutine 1
	/snap/go/10678/src/database/sql/sql.go:791 +0x165

rax    0x0
rbx    0xf
rcx    0x409a8e
rdx    0x6
rdi    0xf
rsi    0x13
rbp    0xc000aff598
rsp    0xc000aff558
r8     0x0
r9     0x0
r10    0x0
r11    0x206
r12    0x0
r13    0x9aaaaaaa5aa0faa8
r14    0xc0000061a0
r15    0x4
rip    0x409a8e
rflags 0x206
cs     0x33
fs     0x0
gs     0x0
</details>

Note that the error is expected due to MySQL not being deployed.