### PR TITLE
Added kubeflow pipelines launcher rock image

### DIFF
--- a/launcher/rockcraft.yaml
+++ b/launcher/rockcraft.yaml
@@ -46,21 +46,18 @@ parts:
       - bash      
     override-build: |
       set -xe
+
+      mkdir -p $CRAFT_PART_INSTALL/bin
+      mkdir -p $CRAFT_PART_INSTALL/third_party
       
-      go build -tags netgo -ldflags '-extldflags "-static"' -o launcher-v2 ./backend/src/v2/cmd/launcher-v2/*.go
+      go build -tags netgo -ldflags '-extldflags "-static"' -o $CRAFT_PART_INSTALL/bin/launcher-v2 $CRAFT_PART_BUILD/backend/src/v2/cmd/launcher-v2/*.go
 
       ./hack/install-go-licenses.sh
 
       $GOBIN/go-licenses check $CRAFT_PART_BUILD/backend/src/v2/cmd/launcher-v2
-      $GOBIN/go-licenses csv $CRAFT_PART_BUILD/backend/src/v2/cmd/launcher-v2 > licenses.csv && \
-      diff licenses.csv $CRAFT_PART_BUILD/backend/third_party_licenses/launcher.csv && \
-      $GOBIN/go-licenses save $CRAFT_PART_BUILD/backend/src/v2/cmd/launcher-v2 --save_path NOTICES
-
-    override-prime: |
-      mkdir -p $CRAFT_PRIME/third_party
-      cp -r $CRAFT_PART_BUILD/launcher-v2 $CRAFT_PRIME/bin
-      cp -r $CRAFT_PART_BUILD/licenses.csv $CRAFT_PRIME/third_party
-      cp -r $CRAFT_PART_BUILD/NOTICES $CRAFT_PRIME/third_party
+      $GOBIN/go-licenses csv $CRAFT_PART_BUILD/backend/src/v2/cmd/launcher-v2 > $CRAFT_PART_INSTALL/third_party/licenses.csv && \
+      diff $CRAFT_PART_INSTALL/third_party/licenses.csv $CRAFT_PART_BUILD/backend/third_party_licenses/launcher.csv && \
+      $GOBIN/go-licenses save $CRAFT_PART_BUILD/backend/src/v2/cmd/launcher-v2 --save_path $CRAFT_PART_INSTALL/third_party/NOTICES
 
   # not-root user for this rock should be 'appuser'  
   non-root-user:

--- a/launcher/rockcraft.yaml
+++ b/launcher/rockcraft.yaml
@@ -3,7 +3,7 @@ name: kfp-launcher
 summary: Kubeflow Pipelines Launcher
 description: |
   Kubeflow Pipelines Launcher is a streamlined interface designed to simplify the creation, management, and deployment of machine learning workflows on Kubernetes.
-version: v2.2.0
+version: 2.2.0
 license: Apache-2.0
 base: ubuntu@22.04
 run-user: _daemon_

--- a/launcher/rockcraft.yaml
+++ b/launcher/rockcraft.yaml
@@ -1,0 +1,76 @@
+# Based on: https://github.com/kubeflow/pipelines/blob/2.2.0/backend/Dockerfile.launcher
+name: kfp-launcher
+summary: Kubeflow Pipelines Launcher
+description: |
+  Kubeflow Pipelines Launcher is a streamlined interface designed to simplify the creation, management, and deployment of machine learning workflows on Kubernetes.
+version: v2.2.0
+license: Apache-2.0
+base: ubuntu@22.04
+run-user: _daemon_
+platforms:
+  amd64:
+
+services:
+  launcher:
+    override: merge
+    summary: "kfp launcher service"
+    startup: enabled
+    user: appuser
+    command: "/bin/launcher-v2"
+
+parts:
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+       dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > \
+       ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+
+  launcher:
+    plugin: go
+    source-type: git    
+    source: https://github.com/kubeflow/pipelines.git
+    source-depth: 1
+    source-tag: 2.2.0   
+    build-snaps:
+      - go/1.21/stable
+    build-packages:
+      - apt
+      - bash
+    build-environment:
+      - CGO_ENABLED: 0
+      - GOOS: linux
+      - GOARCH: amd64
+    stage-packages:
+      - bash      
+    override-build: |
+      set -xe
+      
+      go build -tags netgo -ldflags '-extldflags "-static"' -o launcher-v2 ./backend/src/v2/cmd/launcher-v2/*.go
+
+      ./hack/install-go-licenses.sh
+
+      $GOBIN/go-licenses check $CRAFT_PART_BUILD/backend/src/v2/cmd/launcher-v2
+      $GOBIN/go-licenses csv $CRAFT_PART_BUILD/backend/src/v2/cmd/launcher-v2 > licenses.csv && \
+      diff licenses.csv $CRAFT_PART_BUILD/backend/third_party_licenses/launcher.csv && \
+      $GOBIN/go-licenses save $CRAFT_PART_BUILD/backend/src/v2/cmd/launcher-v2 --save_path NOTICES
+
+    override-prime: |
+      mkdir -p $CRAFT_PRIME/bin/third_party
+      cp -r $CRAFT_PART_BUILD/launcher-v2 $CRAFT_PRIME/bin
+      cp -r $CRAFT_PART_BUILD/licenses.csv $CRAFT_PRIME/bin/third_party
+      cp -r $CRAFT_PART_BUILD/NOTICES $CRAFT_PRIME/bin/third_party
+
+  # not-root user for this rock should be 'appuser'  
+  non-root-user:
+    plugin: nil
+    after: [ launcher ]
+    overlay-script: |
+      # Create a user in the $CRAFT_OVERLAY chroot
+      groupadd -R $CRAFT_OVERLAY -g 1001 appuser
+      useradd -R $CRAFT_OVERLAY -M -r -u 1001 -g appuser appuser
+    override-prime: |
+      craftctl default
+      chown -R 584792:users bin
+      

--- a/launcher/rockcraft.yaml
+++ b/launcher/rockcraft.yaml
@@ -57,10 +57,10 @@ parts:
       $GOBIN/go-licenses save $CRAFT_PART_BUILD/backend/src/v2/cmd/launcher-v2 --save_path NOTICES
 
     override-prime: |
-      mkdir -p $CRAFT_PRIME/bin/third_party
+      mkdir -p $CRAFT_PRIME/third_party
       cp -r $CRAFT_PART_BUILD/launcher-v2 $CRAFT_PRIME/bin
-      cp -r $CRAFT_PART_BUILD/licenses.csv $CRAFT_PRIME/bin/third_party
-      cp -r $CRAFT_PART_BUILD/NOTICES $CRAFT_PRIME/bin/third_party
+      cp -r $CRAFT_PART_BUILD/licenses.csv $CRAFT_PRIME/third_party
+      cp -r $CRAFT_PART_BUILD/NOTICES $CRAFT_PRIME/third_party
 
   # not-root user for this rock should be 'appuser'  
   non-root-user:

--- a/launcher/tests/test_rock.py
+++ b/launcher/tests/test_rock.py
@@ -30,6 +30,21 @@ def test_rock():
         check=True,
     )
 
+    # Assert the rock contains the expected file in /third_party
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            LOCAL_ROCK_IMAGE,
+            "exec",
+            "ls",
+            "-la",
+            "/third_party/NOTICES",
+        ],
+        check=True,
+    )
+
     subprocess.run(
         ["docker", "run", "--rm", LOCAL_ROCK_IMAGE, "exec", "ls", "-la", "/bin/launcher-v2"],
         check=True,

--- a/launcher/tests/test_rock.py
+++ b/launcher/tests/test_rock.py
@@ -1,0 +1,36 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import pytest
+import subprocess
+
+from charmed_kubeflow_chisme.rock import CheckRock
+
+
+@pytest.mark.abort_on_fail
+def test_rock():
+    """Test rock."""
+    check_rock = CheckRock("rockcraft.yaml")
+    rock_image = check_rock.get_name()
+    rock_version = check_rock.get_version()
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
+
+    # assert the rock contains the expected files
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            LOCAL_ROCK_IMAGE,
+            "exec",
+            "ls",
+            "-la",
+            "/bin/third_party",
+        ],
+        check=True,
+    )
+
+    subprocess.run(
+        ["docker", "run", "--rm", LOCAL_ROCK_IMAGE, "exec", "ls", "-la", "/bin/launcher-v2"],
+        check=True,
+    )

--- a/launcher/tests/test_rock.py
+++ b/launcher/tests/test_rock.py
@@ -25,7 +25,7 @@ def test_rock():
             "exec",
             "ls",
             "-la",
-            "/third_party",
+            "/third_party/licenses.csv",
         ],
         check=True,
     )
@@ -40,7 +40,7 @@ def test_rock():
             "exec",
             "ls",
             "-la",
-            "/third_party/NOTICES",
+            "/third_party/NOTICES/",
         ],
         check=True,
     )

--- a/launcher/tests/test_rock.py
+++ b/launcher/tests/test_rock.py
@@ -25,7 +25,7 @@ def test_rock():
             "exec",
             "ls",
             "-la",
-            "/bin/third_party",
+            "/third_party",
         ],
         check=True,
     )

--- a/launcher/tox.ini
+++ b/launcher/tox.ini
@@ -1,0 +1,53 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+envlist = unit, sanity, integration
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+    CHARM_REPO=https://github.com/canonical/kfp-operators.git
+    CHARM_BRANCH=main
+    LOCAL_CHARM_DIR=charm_repo
+
+[testenv:pack]
+passenv = *
+allowlist_externals =
+    rockcraft
+commands =
+    rockcraft pack
+
+[testenv:export-to-docker]
+passenv = *
+allowlist_externals =
+    bash
+    skopeo
+    yq
+commands =
+    # export to docker
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys | .[0]" rockcraft.yaml) && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
+             DOCKER_IMAGE=$NAME:$VERSION && \
+             echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
+             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+
+[testenv:sanity]
+passenv = *
+deps =
+    pytest
+    charmed-kubeflow-chisme
+commands =
+    pytest -s -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+
+[testenv:integration]
+passenv = *
+allowlist_externals =
+    echo
+commands =
+    echo "WARNING: This is a placeholder test - no test is implemented here."
+

--- a/launcher/tox.ini
+++ b/launcher/tox.ini
@@ -3,7 +3,7 @@
 [tox]
 skipsdist = True
 skip_missing_interpreters = True
-envlist = unit, sanity, integration
+envlist = pack, export-to-docker, unit, sanity, integration
 
 [testenv]
 setenv =
@@ -51,3 +51,4 @@ allowlist_externals =
 commands =
     echo "WARNING: This is a placeholder test - no test is implemented here."
 
+>

--- a/launcher/tox.ini
+++ b/launcher/tox.ini
@@ -49,6 +49,5 @@ passenv = *
 allowlist_externals =
     echo
 commands =
+    # TODO: Implement integration tests here
     echo "WARNING: This is a placeholder test - no test is implemented here."
-
->


### PR DESCRIPTION
### Description
---
* Add rockcraft.yaml
* Add tests
* Add tox.ini

This is re-open request for #110.

---
### Logs
Using [kfp-operators](https://github.com/canonical/kfp-operators). Modified [kfp-api/config.yaml](https://github.com/canonical/kfp-operators/blob/main/charms/kfp-api/config.yaml). Replaced "gcr.io/ml-pipeline/kfp-launcher@sha256:bef55a344574a25c557256d7c66cb19edacfd2008d694e5b6bb5b612d59feae0" with "vyurchenko581/kfp-launcher:2.2.0". 

Additionally, the default port for KUBEFLOW_LOCAL_HOST has been changed from 8080 to 8081 due to its unavailability on my local machine, as it is already in use.

Juju status after all tests passed:
```
Model     Controller          Cloud/Region        Version  SLA          Timestamp
kubeflow  microk8s-localhost  microk8s/localhost  3.5.4    unsupported  16:06:46+02:00

App                      Version                  Status  Scale  Charm                    Channel       Rev  Address         Exposed  Message
argo-controller                                   active      1  argo-controller          latest/edge   607  10.152.183.85   no       
envoy                                             active      1  envoy                    latest/edge   307  10.152.183.222  no       
istio-ingressgateway                              active      1  istio-gateway            latest/edge  1287  10.152.183.95   no       
istio-pilot                                       active      1  istio-pilot              latest/edge  1235  10.152.183.61   no       
kfp-api                                           active      1  kfp-api                                  0  10.152.183.219  no       
kfp-db                   8.0.37-0ubuntu0.22.04.3  active      1  mysql-k8s                8.0/stable    180  10.152.183.202  no       
kfp-metadata-writer                               active      1  kfp-metadata-writer                      0  10.152.183.230  no       
kfp-persistence                                   active      1  kfp-persistence                          0  10.152.183.201  no       
kfp-profile-controller                            active      1  kfp-profile-controller                   0  10.152.183.185  no       
kfp-schedwf                                       active      1  kfp-schedwf                              0  10.152.183.173  no       
kfp-ui                                            active      1  kfp-ui                                   0  10.152.183.153  no       
kfp-viewer                                        active      1  kfp-viewer                               0  10.152.183.47   no       
kfp-viz                                           active      1  kfp-viz                                  0  10.152.183.189  no       
kubeflow-profiles                                 active      1  kubeflow-profiles        latest/edge   456  10.152.183.200  no       
kubeflow-roles                                    active      1  kubeflow-roles           latest/edge   264  10.152.183.220  no       
metacontroller-operator                           active      1  metacontroller-operator  latest/edge   349  10.152.183.250  no       
minio                    res:oci-image@220b31a    active      1  minio                    latest/edge   376  10.152.183.21   no       
mlmd                                              active      1  mlmd                     latest/edge   243  10.152.183.121  no       

Unit                        Workload  Agent  Address       Ports          Message
argo-controller/0*          active    idle   10.1.142.144                 
envoy/0*                    active    idle   10.1.142.156                 
istio-ingressgateway/0*     active    idle   10.1.142.179                 
istio-pilot/0*              active    idle   10.1.142.167                 
kfp-api/0*                  active    idle   10.1.142.152                 
kfp-db/0*                   active    idle   10.1.142.145                 Primary
kfp-metadata-writer/0*      active    idle   10.1.142.165                 
kfp-persistence/0*          active    idle   10.1.142.177                 
kfp-profile-controller/0*   active    idle   10.1.142.146                 
kfp-schedwf/0*              active    idle   10.1.142.185                 
kfp-ui/0*                   active    idle   10.1.142.168                 
kfp-viewer/0*               active    idle   10.1.142.181                 
kfp-viz/0*                  active    idle   10.1.142.138                 
kubeflow-profiles/0*        active    idle   10.1.142.143                 
kubeflow-roles/0*           active    idle   10.1.142.161                 
metacontroller-operator/0*  active    idle   10.1.142.188                 
minio/0*                    active    idle   10.1.142.175  9000-9001/TCP  
mlmd/0*                     active    idle   10.1.142.131                 
```

Logs of passed integration tests `tox -vve bundle-integration-v2 -- --model kubeflow --bundle=./tests/integration/bundles/kfp_latest_edge.yaml.j2 --keep-models`:
```
ROOT: 144 D setup logging to DEBUG on pid 778425 [tox/report.py:222]
bundle-integration-v2: 221 D clear env temp folder /home/yurchenko/kfp-operators/.tox/bundle-integration-v2/tmp [tox/tox_env/api.py:313]
bundle-integration-v2: 228 I find interpreter for spec PythonSpec(path=/home/yurchenko/kfp-operators/env/bin/python) [virtualenv/discovery/builtin.py:74]
bundle-integration-v2: 228 D filesystem is case-sensitive [virtualenv/info.py:26]
bundle-integration-v2: 229 D got python info of %s from (PosixPath('/usr/bin/python3.12'), PosixPath('/home/yurchenko/.local/share/virtualenv/py_info/1/f0d7a494a3f776233427cb85a7e198c7cf4913b50a203c6febc678cc4f5bf265.json')) [virtualenv/app_data/via_disk_folder.py:133]
bundle-integration-v2: 229 I proposed PythonInfo(spec=CPython3.12.3.final.0-64, system=/usr/bin/python3.12, exe=/home/yurchenko/kfp-operators/env/bin/python, platform=linux, version='3.12.3 (main, Nov  6 2024, 18:32:19) [GCC 13.2.0]', encoding_fs_io=utf-8-utf-8) [virtualenv/discovery/builtin.py:81]
bundle-integration-v2: 229 D accepted PythonInfo(spec=CPython3.12.3.final.0-64, system=/usr/bin/python3.12, exe=/home/yurchenko/kfp-operators/env/bin/python, platform=linux, version='3.12.3 (main, Nov  6 2024, 18:32:19) [GCC 13.2.0]', encoding_fs_io=utf-8-utf-8) [virtualenv/discovery/builtin.py:83]
bundle-integration-v2: 284 W commands[0]> pytest -vv --tb=native -s --model kubeflow --bundle=./tests/integration/bundles/kfp_latest_edge.yaml.j2 --keep-models /home/yurchenko/kfp-operators/tests/integration/test_kfp_functional_v2.py [tox/tox_env/api.py:427]
/home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/paramiko/pkey.py:100: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES and will be removed from this module in 48.0.0.
  "cipher": algorithms.TripleDES,
/home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/paramiko/transport.py:259: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES and will be removed from this module in 48.0.0.
  "class": algorithms.TripleDES,
============================================================================================= test session starts ==============================================================================================
platform linux -- Python 3.12.3, pytest-8.3.2, pluggy-1.5.0 -- /home/yurchenko/kfp-operators/.tox/bundle-integration-v2/bin/python
cachedir: .tox/bundle-integration-v2/.pytest_cache
rootdir: /home/yurchenko/kfp-operators
configfile: pyproject.toml
plugins: operator-0.35.0, asyncio-0.21.2, anyio-4.4.0
asyncio: mode=Mode.STRICT
collected 6 items                                                                                                                                                                                              

tests/integration/test_kfp_functional_v2.py::test_build_and_deploy PASSED
tests/integration/test_kfp_functional_v2.py::test_upload_pipeline Forwarding from 127.0.0.1:8081 -> 3000
Forwarding from [::1]:8081 -> 3000
Handling connection for 8081
Handling connection for 8081
PASSED
tests/integration/test_kfp_functional_v2.py::test_create_and_monitor_run Handling connection for 8081
Handling connection for 8081
Experiment details: http://localhost:8081/#/experiments/details/7e354753-7948-4b16-8acf-253aa0ac1cc5
Handling connection for 8081
Experiment details: http://localhost:8081/#/experiments/details/7e354753-7948-4b16-8acf-253aa0ac1cc5
Handling connection for 8081
Run details: http://localhost:8081/#/runs/details/9e20574f-9b5a-4627-acae-653a8e9db392
Handling connection for 8081
Handling connection for 8081
Handling connection for 8081
Handling connection for 8081
Handling connection for 8081
Handling connection for 8081
Handling connection for 8081
Handling connection for 8081
PASSEDHandling connection for 8081

tests/integration/test_kfp_functional_v2.py::test_create_and_monitor_recurring_run Handling connection for 8081
Handling connection for 8081
Handling connection for 8081
Handling connection for 8081
Experiment details: http://localhost:8081/#/experiments/details/32d694e6-9097-468e-b745-da65c7a37b0b
Handling connection for 8081
Handling connection for 8081
Handling connection for 8081
Handling connection for 8081
Handling connection for 8081
Handling connection for 8081
Handling connection for 8081
PASSEDHandling connection for 8081
Handling connection for 8081
Handling connection for 8081

tests/integration/test_kfp_functional_v2.py::test_apply_sample_viewer PASSED
tests/integration/test_kfp_functional_v2.py::test_viz_server_healthcheck PASSED

=============================================================================================== warnings summary ===============================================================================================
tests/integration/test_kfp_functional_v2.py::test_build_and_deploy
  /home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/sh.py:1980: DeprecationWarning: This process (pid=778431) is multi-threaded, use of fork() may lead to deadlocks in the child.
    self.pid = os.fork()

tests/integration/test_kfp_functional_v2.py::test_upload_pipeline
  /home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/kfp/client/client.py:159: FutureWarning: This client only works with Kubeflow Pipeline v2.0.0-beta.2 and later versions.
    warnings.warn(

tests/integration/test_kfp_functional_v2.py: 29 warnings
  /home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/kfp_server_api/rest.py:47: DeprecationWarning: HTTPResponse.getheader() is deprecated and will be removed in urllib3 v2.1.0. Instead use HTTPResponse.headers.get(name, default).
    return self.urllib3_response.getheader(name, default)

tests/integration/test_kfp_functional_v2.py::test_viz_server_healthcheck
  /home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/_pytest/stash.py:108: RuntimeWarning: coroutine 'Connection.reconnect' was never awaited
    del self._storage[key]
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================== 6 passed, 32 warnings in 425.60s (0:07:05) ==================================================================================
Task exception was never retrieved
future: <Task finished name='Task-32' coro=<Model._watch.<locals>._all_watcher() done, defined at /home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/juju/model.py:1194> exception=TypeError('Passing coroutines is forbidden, use tasks explicitly.')>
Traceback (most recent call last):
  File "/home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/websockets/legacy/protocol.py", line 1301, in close_connection
    await self.transfer_data_task
  File "/home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/websockets/legacy/protocol.py", line 963, in transfer_data
    message = await self.read_message()
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/websockets/legacy/protocol.py", line 1033, in read_message
    frame = await self.read_data_frame(max_size=self.max_size)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/websockets/legacy/protocol.py", line 1108, in read_data_frame
    frame = await self.read_frame(max_size)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/websockets/legacy/protocol.py", line 1165, in read_frame
    frame = await Frame.read(
            ^^^^^^^^^^^^^^^^^
  File "/home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/websockets/legacy/framing.py", line 68, in read
    data = await reader(2)
           ^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/streams.py", line 752, in readexactly
    await self._wait_for_data('readexactly')
  File "/usr/lib/python3.12/asyncio/streams.py", line 545, in _wait_for_data
    await self._waiter
asyncio.exceptions.CancelledError

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/juju/client/connection.py", line 649, in rpc
    await self._ws.send(outgoing)
  File "/home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/websockets/legacy/protocol.py", line 635, in send
    await self.ensure_open()
  File "/home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/websockets/legacy/protocol.py", line 939, in ensure_open
    raise self.connection_closed_exc()
websockets.exceptions.ConnectionClosedError: sent 1011 (internal error) keepalive ping timeout; no close frame received

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/juju/model.py", line 1206, in _all_watcher
    results = await utils.run_with_interrupt(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/juju/utils.py", line 191, in run_with_interrupt
    return task.result()  # may raise exception
           ^^^^^^^^^^^^^
TypeError: Passing coroutines is forbidden, use tasks explicitly.
bundle-integration-v2: 427498 I exit 0 (427.21 seconds) /home/yurchenko/kfp-operators> pytest -vv --tb=native -s --model kubeflow --bundle=./tests/integration/bundles/kfp_latest_edge.yaml.j2 --keep-models /home/yurchenko/kfp-operators/tests/integration/test_kfp_functional_v2.py pid=778431 [tox/execute/api.py:286]
  bundle-integration-v2: OK (427.28=setup[0.07]+cmd[427.21] seconds)
  congratulations :) (427.36 seconds)
```

