### PR TITLE
Added kubeflow pipelines driver rock image

### DIFF
--- a/driver/rockcraft.yaml
+++ b/driver/rockcraft.yaml
@@ -2,7 +2,7 @@
 name: kfp-driver
 summary: Kubeflow Pipelines Driver
 description: This image is used as part of the Charmed Kubeflow product
-version: v2.2.0
+version: 2.2.0
 license: Apache-2.0
 base: ubuntu@22.04
 run-user: _daemon_

--- a/driver/rockcraft.yaml
+++ b/driver/rockcraft.yaml
@@ -45,26 +45,23 @@ parts:
       - bash      
     override-build: |
       set -xe
+
+      mkdir -p $CRAFT_PART_INSTALL/bin
+      mkdir -p $CRAFT_PART_INSTALL/third_party
       
-      go build -tags netgo -ldflags '-extldflags "-static"' -o driver ./backend/src/v2/cmd/launcher-v2/*.go
+      go build -tags netgo -ldflags '-extldflags "-static"' -o $CRAFT_PART_INSTALL/bin/driver $CRAFT_PART_BUILD/backend/src/v2/cmd/driver/*.go
 
       ./hack/install-go-licenses.sh
 
       $GOBIN/go-licenses check $CRAFT_PART_BUILD/backend/src/v2/cmd/driver
-      $GOBIN/go-licenses csv $CRAFT_PART_BUILD/backend/src/v2/cmd/driver > licenses.csv && \
-      diff licenses.csv $CRAFT_PART_BUILD/backend/third_party_licenses/driver.csv && \
-      $GOBIN/go-licenses save $CRAFT_PART_BUILD/backend/src/v2/cmd/driver --save_path NOTICES
-
-    override-prime: |
-      mkdir -p $CRAFT_PRIME/third_party
-      cp -r $CRAFT_PART_BUILD/driver $CRAFT_PRIME/bin
-      cp -r $CRAFT_PART_BUILD/licenses.csv $CRAFT_PRIME/third_party
-      cp -r $CRAFT_PART_BUILD/NOTICES $CRAFT_PRIME/third_party
+      $GOBIN/go-licenses csv $CRAFT_PART_BUILD/backend/src/v2/cmd/driver > $CRAFT_PART_INSTALL/third_party/licenses.csv && \
+      diff $CRAFT_PART_INSTALL/third_party/licenses.csv $CRAFT_PART_BUILD/backend/third_party_licenses/driver.csv && \
+      $GOBIN/go-licenses save $CRAFT_PART_BUILD/backend/src/v2/cmd/driver --save_path $CRAFT_PART_INSTALL/third_party/NOTICES
 
   # not-root user for this rock should be 'appuser'  
   non-root-user:
     plugin: nil
-    after: [ launcher ]
+    after: [ driver ]
     overlay-script: |
       # Create a user in the $CRAFT_OVERLAY chroot
       groupadd -R $CRAFT_OVERLAY -g 1001 appuser

--- a/driver/rockcraft.yaml
+++ b/driver/rockcraft.yaml
@@ -1,0 +1,75 @@
+# Based on: https://github.com/kubeflow/pipelines/blob/2.2.0/backend/Dockerfile.driver
+name: kfp-driver
+summary: Kubeflow Pipelines Driver
+description: This image is used as part of the Charmed Kubeflow product
+version: v2.2.0
+license: Apache-2.0
+base: ubuntu@22.04
+run-user: _daemon_
+platforms:
+  amd64:
+
+services:
+  launcher:
+    override: merge
+    summary: "kfp driver service"
+    startup: enabled
+    user: appuser
+    command: "/bin/driver"
+
+parts:
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+       dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > \
+       ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+
+  driver:
+    plugin: go
+    source-type: git    
+    source: https://github.com/kubeflow/pipelines.git
+    source-depth: 1
+    source-tag: 2.2.0   
+    build-snaps:
+      - go/1.21/stable
+    build-packages:
+      - apt
+      - bash
+    build-environment:
+      - CGO_ENABLED: 0
+      - GOOS: linux
+      - GOARCH: amd64
+    stage-packages:
+      - bash      
+    override-build: |
+      set -xe
+      
+      go build -tags netgo -ldflags '-extldflags "-static"' -o driver ./backend/src/v2/cmd/launcher-v2/*.go
+
+      ./hack/install-go-licenses.sh
+
+      $GOBIN/go-licenses check $CRAFT_PART_BUILD/backend/src/v2/cmd/driver
+      $GOBIN/go-licenses csv $CRAFT_PART_BUILD/backend/src/v2/cmd/driver > licenses.csv && \
+      diff licenses.csv $CRAFT_PART_BUILD/backend/third_party_licenses/driver.csv && \
+      $GOBIN/go-licenses save $CRAFT_PART_BUILD/backend/src/v2/cmd/driver --save_path NOTICES
+
+    override-prime: |
+      mkdir -p $CRAFT_PRIME/third_party
+      cp -r $CRAFT_PART_BUILD/driver $CRAFT_PRIME/bin
+      cp -r $CRAFT_PART_BUILD/licenses.csv $CRAFT_PRIME/third_party
+      cp -r $CRAFT_PART_BUILD/NOTICES $CRAFT_PRIME/third_party
+
+  # not-root user for this rock should be 'appuser'  
+  non-root-user:
+    plugin: nil
+    after: [ launcher ]
+    overlay-script: |
+      # Create a user in the $CRAFT_OVERLAY chroot
+      groupadd -R $CRAFT_OVERLAY -g 1001 appuser
+      useradd -R $CRAFT_OVERLAY -M -r -u 1001 -g appuser appuser
+    override-prime: |
+      craftctl default
+      chown -R 584792:users bin
+      

--- a/driver/tests/test_rock.py
+++ b/driver/tests/test_rock.py
@@ -1,0 +1,36 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import pytest
+import subprocess
+
+from charmed_kubeflow_chisme.rock import CheckRock
+
+
+@pytest.mark.abort_on_fail
+def test_rock():
+    """Test rock."""
+    check_rock = CheckRock("rockcraft.yaml")
+    rock_image = check_rock.get_name()
+    rock_version = check_rock.get_version()
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
+
+    # assert the rock contains the expected files
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            LOCAL_ROCK_IMAGE,
+            "exec",
+            "ls",
+            "-la",
+            "/third_party",
+        ],
+        check=True,
+    )
+
+    subprocess.run(
+        ["docker", "run", "--rm", LOCAL_ROCK_IMAGE, "exec", "ls", "-la", "/bin/driver"],
+        check=True,
+    )

--- a/driver/tests/test_rock.py
+++ b/driver/tests/test_rock.py
@@ -25,7 +25,7 @@ def test_rock():
             "exec",
             "ls",
             "-la",
-            "/third_party",
+            "/third_party/licenses.csv",
         ],
         check=True,
     )
@@ -40,7 +40,7 @@ def test_rock():
             "exec",
             "ls",
             "-la",
-            "/third_party/NOTICES",
+            "/third_party/NOTICES/",
         ],
         check=True,
     )

--- a/driver/tests/test_rock.py
+++ b/driver/tests/test_rock.py
@@ -30,6 +30,21 @@ def test_rock():
         check=True,
     )
 
+    # Assert the rock contains the expected file in /third_party
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            LOCAL_ROCK_IMAGE,
+            "exec",
+            "ls",
+            "-la",
+            "/third_party/NOTICES",
+        ],
+        check=True,
+    )
+
     subprocess.run(
         ["docker", "run", "--rm", LOCAL_ROCK_IMAGE, "exec", "ls", "-la", "/bin/driver"],
         check=True,

--- a/driver/tox.ini
+++ b/driver/tox.ini
@@ -1,0 +1,53 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+envlist = pack, export-to-docker, unit, sanity, integration
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+    CHARM_REPO=https://github.com/canonical/kfp-operators.git
+    CHARM_BRANCH=main
+    LOCAL_CHARM_DIR=charm_repo
+
+[testenv:pack]
+passenv = *
+allowlist_externals =
+    rockcraft
+commands =
+    rockcraft pack
+
+[testenv:export-to-docker]
+passenv = *
+allowlist_externals =
+    bash
+    skopeo
+    yq
+commands =
+    # export to docker
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys | .[0]" rockcraft.yaml) && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
+             DOCKER_IMAGE=$NAME:$VERSION && \
+             echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
+             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+
+[testenv:sanity]
+passenv = *
+deps =
+    pytest
+    charmed-kubeflow-chisme
+commands =
+    pytest -s -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+
+[testenv:integration]
+passenv = *
+allowlist_externals =
+    echo
+commands =
+    # TODO: Implement integration tests here
+    echo "WARNING: This is a placeholder test - no test is implemented here."


### PR DESCRIPTION
### Description
---
* Add rockcraft.yaml
* Add tests
* Add tox.ini

This is re-open request for #109.

---
### Logs
Using [kfp-operators](https://github.com/canonical/kfp-operators). Modified [kfp-api/config.yaml](https://github.com/canonical/kfp-operators/blob/main/charms/kfp-api/config.yaml). Replaced "gcr.io/ml-pipeline/kfp-driver" with "vyurchenko581/kfp-driver:2.2.0". 

Additionally, the default port for KUBEFLOW_LOCAL_HOST has been changed from 8080 to 8081 due to its unavailability on my local machine, as it is already in use.

Juju status after all tests passed:
```
Model     Controller          Cloud/Region        Version  SLA          Timestamp
kubeflow  microk8s-localhost  microk8s/localhost  3.5.4    unsupported  14:32:11+02:00

App                      Version                  Status  Scale  Charm                    Channel       Rev  Address         Exposed  Message
argo-controller                                   active      1  argo-controller          latest/edge   615  10.152.183.134  no       
envoy                                             active      1  envoy                    latest/edge   307  10.152.183.51   no       
istio-ingressgateway                              active      1  istio-gateway            latest/edge  1287  10.152.183.229  no       
istio-pilot                                       active      1  istio-pilot              latest/edge  1235  10.152.183.61   no       
kfp-api                                           active      1  kfp-api                                  0  10.152.183.191  no       
kfp-db                   8.0.37-0ubuntu0.22.04.3  active      1  mysql-k8s                8.0/stable    180  10.152.183.188  no       
kfp-metadata-writer                               active      1  kfp-metadata-writer                      0  10.152.183.184  no       
kfp-persistence                                   active      1  kfp-persistence                          0  10.152.183.196  no       
kfp-profile-controller                            active      1  kfp-profile-controller                   0  10.152.183.246  no       
kfp-schedwf                                       active      1  kfp-schedwf                              0  10.152.183.91   no       
kfp-ui                                            active      1  kfp-ui                                   0  10.152.183.69   no       
kfp-viewer                                        active      1  kfp-viewer                               0  10.152.183.183  no       
kfp-viz                                           active      1  kfp-viz                                  0  10.152.183.252  no       
kubeflow-profiles                                 active      1  kubeflow-profiles        latest/edge   456  10.152.183.70   no       
kubeflow-roles                                    active      1  kubeflow-roles           latest/edge   264  10.152.183.62   no       
metacontroller-operator                           active      1  metacontroller-operator  latest/edge   349  10.152.183.107  no       
minio                    res:oci-image@220b31a    active      1  minio                    latest/edge   376  10.152.183.233  no       
mlmd                                              active      1  mlmd                     latest/edge   243  10.152.183.47   no       

Unit                        Workload  Agent  Address       Ports          Message
argo-controller/0*          active    idle   10.1.142.172                 
envoy/0*                    active    idle   10.1.142.158                 
istio-ingressgateway/0*     active    idle   10.1.142.176                 
istio-pilot/0*              active    idle   10.1.142.188                 
kfp-api/0*                  active    idle   10.1.142.140                 
kfp-db/0*                   active    idle   10.1.142.129                 Primary
kfp-metadata-writer/0*      active    idle   10.1.142.148                 
kfp-persistence/0*          active    idle   10.1.142.133                 
kfp-profile-controller/0*   active    idle   10.1.142.191                 
kfp-schedwf/0*              active    idle   10.1.142.130                 
kfp-ui/0*                   active    idle   10.1.142.157                 
kfp-viewer/0*               active    idle   10.1.142.159                 
kfp-viz/0*                  active    idle   10.1.142.136                 
kubeflow-profiles/0*        active    idle   10.1.142.170                 
kubeflow-roles/0*           active    idle   10.1.142.180                 
metacontroller-operator/0*  active    idle   10.1.142.173                 
minio/0*                    active    idle   10.1.142.163  9000-9001/TCP  
mlmd/0*                     active    idle   10.1.142.151                 
```

Logs of passed integration tests `tox -vve bundle-integration-v2 -- --model kubeflow --bundle=./tests/integration/bundles/kfp_latest_edge.yaml.j2 --keep-models`:
```
ROOT: 244 D setup logging to DEBUG on pid 2001545 [tox/report.py:222]
bundle-integration-v2: 330 D clear env temp folder /home/yurchenko/kfp-operators/.tox/bundle-integration-v2/tmp [tox/tox_env/api.py:313]
bundle-integration-v2: 339 I find interpreter for spec PythonSpec(path=/home/yurchenko/kfp-operators/env/bin/python) [virtualenv/discovery/builtin.py:74]
bundle-integration-v2: 340 D filesystem is case-sensitive [virtualenv/info.py:26]
bundle-integration-v2: 341 D got python info of %s from (PosixPath('/usr/bin/python3.12'), PosixPath('/home/yurchenko/.local/share/virtualenv/py_info/1/f0d7a494a3f776233427cb85a7e198c7cf4913b50a203c6febc678cc4f5bf265.json')) [virtualenv/app_data/via_disk_folder.py:133]
bundle-integration-v2: 341 I proposed PythonInfo(spec=CPython3.12.3.final.0-64, system=/usr/bin/python3.12, exe=/home/yurchenko/kfp-operators/env/bin/python, platform=linux, version='3.12.3 (main, Nov  6 2024, 18:32:19) [GCC 13.2.0]', encoding_fs_io=utf-8-utf-8) [virtualenv/discovery/builtin.py:81]
bundle-integration-v2: 341 D accepted PythonInfo(spec=CPython3.12.3.final.0-64, system=/usr/bin/python3.12, exe=/home/yurchenko/kfp-operators/env/bin/python, platform=linux, version='3.12.3 (main, Nov  6 2024, 18:32:19) [GCC 13.2.0]', encoding_fs_io=utf-8-utf-8) [virtualenv/discovery/builtin.py:83]
bundle-integration-v2: 392 W commands[0]> pytest -vv --tb=native -s --model kubeflow --bundle=./tests/integration/bundles/kfp_latest_edge.yaml.j2 --keep-models /home/yurchenko/kfp-operators/tests/integration/test_kfp_functional_v2.py [tox/tox_env/api.py:427]
/home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/paramiko/pkey.py:100: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES and will be removed from this module in 48.0.0.
  "cipher": algorithms.TripleDES,
/home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/paramiko/transport.py:259: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES and will be removed from this module in 48.0.0.
  "class": algorithms.TripleDES,
============================================================================================= test session starts ==============================================================================================
platform linux -- Python 3.12.3, pytest-8.3.2, pluggy-1.5.0 -- /home/yurchenko/kfp-operators/.tox/bundle-integration-v2/bin/python
cachedir: .tox/bundle-integration-v2/.pytest_cache
rootdir: /home/yurchenko/kfp-operators
configfile: pyproject.toml
plugins: operator-0.35.0, asyncio-0.21.2, anyio-4.4.0
asyncio: mode=Mode.STRICT
collected 6 items                                                                                                                                                                                              

tests/integration/test_kfp_functional_v2.py::test_build_and_deploy PASSED
tests/integration/test_kfp_functional_v2.py::test_upload_pipeline Forwarding from 127.0.0.1:8081 -> 3000
Forwarding from [::1]:8081 -> 3000
Handling connection for 8081
Handling connection for 8081
PASSED
tests/integration/test_kfp_functional_v2.py::test_create_and_monitor_run Handling connection for 8081
Handling connection for 8081
Experiment details: http://localhost:8081/#/experiments/details/0886d7d7-9fa4-43f4-ab66-45cc077bf044
Handling connection for 8081
Experiment details: http://localhost:8081/#/experiments/details/0886d7d7-9fa4-43f4-ab66-45cc077bf044
Handling connection for 8081
Run details: http://localhost:8081/#/runs/details/8c1bfee7-1f3f-4185-877e-dc8679f49c23
Handling connection for 8081
Handling connection for 8081
Handling connection for 8081
Handling connection for 8081
Handling connection for 8081
Handling connection for 8081
Handling connection for 8081
Handling connection for 8081
Handling connection for 8081
Handling connection for 8081
PASSEDHandling connection for 8081

tests/integration/test_kfp_functional_v2.py::test_create_and_monitor_recurring_run Handling connection for 8081
Handling connection for 8081
Handling connection for 8081
Handling connection for 8081
Experiment details: http://localhost:8081/#/experiments/details/08bd7e76-b6b8-4a0a-90a3-48bea3d9e57e
Handling connection for 8081
Handling connection for 8081
Handling connection for 8081
Handling connection for 8081
Handling connection for 8081
Handling connection for 8081
Handling connection for 8081
PASSEDHandling connection for 8081
Handling connection for 8081
Handling connection for 8081

tests/integration/test_kfp_functional_v2.py::test_apply_sample_viewer PASSED
tests/integration/test_kfp_functional_v2.py::test_viz_server_healthcheck PASSED

=============================================================================================== warnings summary ===============================================================================================
tests/integration/test_kfp_functional_v2.py::test_build_and_deploy
  /home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/sh.py:1980: DeprecationWarning: This process (pid=2001570) is multi-threaded, use of fork() may lead to deadlocks in the child.
    self.pid = os.fork()

tests/integration/test_kfp_functional_v2.py::test_upload_pipeline
  /home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/kfp/client/client.py:159: FutureWarning: This client only works with Kubeflow Pipeline v2.0.0-beta.2 and later versions.
    warnings.warn(

tests/integration/test_kfp_functional_v2.py: 31 warnings
  /home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/kfp_server_api/rest.py:47: DeprecationWarning: HTTPResponse.getheader() is deprecated and will be removed in urllib3 v2.1.0. Instead use HTTPResponse.headers.get(name, default).
    return self.urllib3_response.getheader(name, default)

tests/integration/test_kfp_functional_v2.py::test_viz_server_healthcheck
  /home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/_pytest/stash.py:108: RuntimeWarning: coroutine 'Connection.reconnect' was never awaited
    del self._storage[key]
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================== 6 passed, 34 warnings in 441.17s (0:07:21) ==================================================================================
Task exception was never retrieved
future: <Task finished name='Task-32' coro=<Model._watch.<locals>._all_watcher() done, defined at /home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/juju/model.py:1194> exception=TypeError('Passing coroutines is forbidden, use tasks explicitly.')>
Traceback (most recent call last):
  File "/home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/websockets/legacy/protocol.py", line 1301, in close_connection
    await self.transfer_data_task
  File "/home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/websockets/legacy/protocol.py", line 963, in transfer_data
    message = await self.read_message()
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/websockets/legacy/protocol.py", line 1033, in read_message
    frame = await self.read_data_frame(max_size=self.max_size)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/websockets/legacy/protocol.py", line 1108, in read_data_frame
    frame = await self.read_frame(max_size)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/websockets/legacy/protocol.py", line 1165, in read_frame
    frame = await Frame.read(
            ^^^^^^^^^^^^^^^^^
  File "/home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/websockets/legacy/framing.py", line 68, in read
    data = await reader(2)
           ^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/streams.py", line 752, in readexactly
    await self._wait_for_data('readexactly')
  File "/usr/lib/python3.12/asyncio/streams.py", line 545, in _wait_for_data
    await self._waiter
asyncio.exceptions.CancelledError

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/juju/client/connection.py", line 649, in rpc
    await self._ws.send(outgoing)
  File "/home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/websockets/legacy/protocol.py", line 635, in send
    await self.ensure_open()
  File "/home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/websockets/legacy/protocol.py", line 939, in ensure_open
    raise self.connection_closed_exc()
websockets.exceptions.ConnectionClosedError: sent 1011 (internal error) keepalive ping timeout; no close frame received

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/juju/model.py", line 1206, in _all_watcher
    results = await utils.run_with_interrupt(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yurchenko/kfp-operators/.tox/bundle-integration-v2/lib/python3.12/site-packages/juju/utils.py", line 191, in run_with_interrupt
    return task.result()  # may raise exception
           ^^^^^^^^^^^^^
TypeError: Passing coroutines is forbidden, use tasks explicitly.
bundle-integration-v2: 443121 I exit 0 (442.73 seconds) /home/yurchenko/kfp-operators> pytest -vv --tb=native -s --model kubeflow --bundle=./tests/integration/bundles/kfp_latest_edge.yaml.j2 --keep-models /home/yurchenko/kfp-operators/tests/integration/test_kfp_functional_v2.py pid=2001570 [tox/execute/api.py:286]
  bundle-integration-v2: OK (442.79=setup[0.07]+cmd[442.73] seconds)
  congratulations :) (442.88 seconds)
```