### PR TITLE
fix(metadata-writer): Use the same service name with charm

### DIFF
--- a/metadata-writer/rockcraft.yaml
+++ b/metadata-writer/rockcraft.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 base: ubuntu@22.04
 run-user: _daemon_
 services:
-  controller:
+  kfp-metadata-writer:
     override: replace
     summary: "Entry point for kfp-metadata-writer oci-image"
     startup: enabled


### PR DESCRIPTION
Modify rock's service name to be the same with the one that the charm uses.

Ref #166