### PR TITLE
feat: update `api-server` rock to v2.4.0

### DIFF
--- a/api-server/rockcraft.yaml
+++ b/api-server/rockcraft.yaml
@@ -1,8 +1,8 @@
-# Dockerfile: https://github.com/kubeflow/pipelines/blob/2.3.0/backend/Dockerfile
+# Dockerfile: https://github.com/kubeflow/pipelines/blob/2.4.0/backend/Dockerfile
 name: api-server
 summary: An image for using Kubeflow pipelines API
 description: An image for using Kubeflow pipelines API
-version: "2.3.0"
+version: "2.4.0"
 base: ubuntu@22.04
 license: Apache-2.0
 platforms:
@@ -35,9 +35,9 @@ parts:
   builder:
     plugin: go
     source: https://github.com/kubeflow/pipelines.git
-    source-tag: 2.3.0
+    source-tag: 2.4.0
     build-snaps:
-      - go/1.21/stable
+      - go/1.22/stable
     build-environment:
       - GO111MODULE: "on"
     build-packages:
@@ -59,15 +59,15 @@ parts:
   compiler:
     plugin: nil
     source: https://github.com/kubeflow/pipelines.git
-    source-tag: 2.3.0
+    source-tag: 2.4.0
     build-environment:
       - ARGO_VERSION: v3.4.17
     build-packages:
       - default-jdk
-      - python3.8
+      - python3.9
       # required to build google-cloud-profiler wheel for pyproject.toml-based projects
-      - python3.8-dev
-      - python3.8-distutils
+      - python3.9-dev
+      - python3.9-distutils
       - jq
       - wget
 
@@ -78,7 +78,7 @@ parts:
       rm -rf ./*
 
       # Create a symbolic link so the rest of this script is like upstream
-      ln -s /usr/bin/python3.8 python3
+      ln -s /usr/bin/python3.9 python3
       PATH=.:$PATH
 
       # Setup pip
@@ -111,7 +111,7 @@ parts:
     after: [builder, compiler]
     plugin: nil
     source: https://github.com/kubeflow/pipelines.git
-    source-tag: 2.3.0
+    source-tag: 2.4.0
     build-packages:
       - ca-certificates
       - wget


### PR DESCRIPTION
Closes: https://warthogs.atlassian.net/browse/KF-6801

Updates comparison [here](https://www.diffchecker.com/Jtt91q8S/): 
- new version of go
- new version of python for building

Steps to test 
```
rockcraft clean && rockcraft pack --verbosity=trace --debug
sudo rockcraft.skopeo --insecure-policy copy oci-archive:api-server_2.4.0_amd64.rock docker-daemon:misohu/api-server:2.4.0
docker run <image>
docker exec -ti <container> bash
/bin/apiserver --config=/config --sampleconfig=/config/sample_config.json -logtostderr=true --logLevel=$LOG_LEVEL

# Expected output
I0205 09:11:49.968874      26 client_manager.go:170] Initializing client manager
I0205 09:11:49.968915      26 client_manager.go:171] Initializing DB client...
I0205 09:11:49.968938      26 config.go:57] Config DBConfig.MySQLConfig.ExtraParams not specified, skipping
````
