### PR TITLE
feat: update metadata-writer rock to 2.4.0

### DIFF
--- a/metadata-writer/rockcraft.yaml
+++ b/metadata-writer/rockcraft.yaml
@@ -44,7 +44,7 @@ parts:
     build-environment: 
     - PARTS_PYTHON_INTERPRETER: python3.9
 
-  python3-is-python3.8:
+  python3-is-python3.9:
     plugin: nil
     override-build: |
       # Ensure `python3` is an executable command in our primed image by making

--- a/metadata-writer/rockcraft.yaml
+++ b/metadata-writer/rockcraft.yaml
@@ -1,9 +1,9 @@
-# Based on: https://github.com/kubeflow/pipelines/blob/2.3.0/backend/metadata_writer/Dockerfile
+# Based on: https://github.com/kubeflow/pipelines/blob/2.4.0/backend/metadata_writer/Dockerfile
 name: metadata-writer
 summary: Reusable end-to-end ML workflows built using the Kubeflow Pipelines SDK
 description: |
   This service logs the metadata for KFP components and pipelines.
-version: "2.3.0"
+version: "2.4.0"
 license: Apache-2.0
 base: ubuntu@22.04
 run-user: _daemon_
@@ -34,15 +34,15 @@ parts:
     plugin: python
     source: https://github.com/kubeflow/pipelines.git
     source-subdir: backend/metadata_writer
-    source-tag: 2.3.0
+    source-tag: 2.4.0
     stage-packages:
       # sync this python version to the base image in the Dockerfile.
       # Also keep this in sync with PARTS_PYTHON_INTERPRETER below.
-    - python3.8-venv
+    - python3.9-venv
     python-requirements:
     - requirements.txt
     build-environment: 
-    - PARTS_PYTHON_INTERPRETER: python3.8
+    - PARTS_PYTHON_INTERPRETER: python3.9
 
   python3-is-python3.8:
     plugin: nil
@@ -50,12 +50,12 @@ parts:
       # Ensure `python3` is an executable command in our primed image by making
       # a symbolic link
       mkdir -p $CRAFT_PART_INSTALL/usr/bin/
-      ln -s /usr/bin/python3.8 $CRAFT_PART_INSTALL/usr/bin/python3
+      ln -s /usr/bin/python3.9 $CRAFT_PART_INSTALL/usr/bin/python3
 
   copy-files:
     plugin: nil
     source: https://github.com/kubeflow/pipelines.git
-    source-tag: 2.3.0
+    source-tag: 2.4.0
     override-build: |
       mkdir -p ${CRAFT_PART_INSTALL}/kfp/metadata_writer/
       cp  ${CRAFT_PART_SRC}/backend/metadata_writer/src/* ${CRAFT_PART_INSTALL}/kfp/metadata_writer


### PR DESCRIPTION
Closes: https://warthogs.atlassian.net/browse/KF-6814

Compared with upstream changes https://www.diffchecker.com/Bn0XdYlk/

Changes and reasoning:
- Python version change

To test:
```
rockcraft clean && rockcraft pack --verbosity=trace --debug
sudo rockcraft.skopeo --insecure-policy copy oci-archive:metadata-writer_2.4.0_amd64.rock docker-daemon:misohu/metadata-writer:2.4.0
docker run <image>
docker exec -ti <container> bash

python3 -u /kfp/metadata_writer/metadata_writer.py
# Expected output
Traceback (most recent call last):
  File "/kfp/metadata_writer/metadata_writer.py", line 39, in <module>
    kubernetes.config.load_incluster_config()
  File "/usr/local/lib/python3.9/dist-packages/kubernetes/config/incluster_config.py", line 118, in load_incluster_config
    InClusterConfigLoader(
  File "/usr/local/lib/python3.9/dist-packages/kubernetes/config/incluster_config.py", line 54, in load_and_set
    self._load_config()
  File "/usr/local/lib/python3.9/dist-packages/kubernetes/config/incluster_config.py", line 62, in _load_config
    raise ConfigException("Service host/port is not set.")
 ```