### PR TITLE
feat: update persistenceagent rock to 2.4.0

### DIFF
--- a/persistenceagent/rockcraft.yaml
+++ b/persistenceagent/rockcraft.yaml
@@ -1,9 +1,9 @@
-# Based on: https://github.com/kubeflow/pipelines/blob/2.3.0/backend/Dockerfile.persistenceagent
+# Based on: https://github.com/kubeflow/pipelines/blob/2.4.0/backend/Dockerfile.persistenceagent
 name: persistenceagent
 summary: Reusable end-to-end ML workflows built using the Kubeflow Pipelines SDK
 description: |
   This component serves as the backend persistence agent of Kubeflow pipelines.
-version: "2.3.0"
+version: "2.4.0"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:
@@ -35,9 +35,9 @@ parts:
     plugin: go
     source: https://github.com/kubeflow/pipelines
     source-type: git
-    source-tag: 2.3.0
+    source-tag: 2.4.0
     build-snaps:
-      - go/1.21/stable
+      - go/1.22/stable
     build-packages:
       - git
       - openssl


### PR DESCRIPTION
Closes: https://warthogs.atlassian.net/browse/KF-6819

Changes and reasoning:
- Go version bump

To test:
```
rockcraft clean && rockcraft pack --verbosity=trace --debug
sudo rockcraft.skopeo --insecure-policy copy oci-archive:persistenceagent_2.4.0_amd64.rock docker-daemon:misohu/persistenceagent:2.4.0
docker run <image>
docker exec -ti <container> bash

python3 -u /kfp/metadata_writer/metadata_writer.py
# Expected output
2025-02-06T09:35:33.928Z [persistenceagent] W0206 09:35:33.928456      15 client_config.go:659] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
2025-02-06T09:35:33.928Z [persistenceagent] W0206 09:35:33.928519      15 client_config.go:664] error creating inClusterConfig, falling back to default config: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined
2025-02-06T09:35:33.928Z [persistenceagent] time="2025-02-06T09:35:33Z" level=fatal msg="Error building kubeconfig: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable"
2025-02-06T09:35:34.523Z [persistenceagent] W0206 09:35:34.523682      32 client_config.go:659] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
2025-02-06T09:35:34.523Z [persistenceagent] W0206 09:35:34.523721      32 client_config.go:664] error creating inClusterConfig, falling back to default config: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined
2025-02-06T09:35:34.523Z [persistenceagent] time="2025-02-06T09:35:34Z" level=fatal msg="Error building kubeconfig: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable"
2025-02-06T09:35:35.655Z [persistenceagent] W0206 09:35:35.655683      50 client_config.go:659] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
2025-02-06T09:35:35.655Z [persistenceagent] W0206 09:35:35.655732      50 client_config.go:664] error creating inClusterConfig, falling back to default config: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined
2025-02-06T09:35:35.655Z [persistenceagent] time="2025-02-06T09:35:35Z" level=fatal msg="Error building kubeconfig: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable"
2025-02-06T09:35:37.854Z [persistenceagent] W0206 09:35:37.854758      67 client_config.go:659] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
2025-02-06T09:35:37.854Z [persistenceagent] W0206 09:35:37.854849      67 client_config.go:664] error creating inClusterConfig, falling back to default config: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined
2025-02-06T09:35:37.855Z [persistenceagent] time="2025-02-06T09:35:37Z" level=fatal msg="Error building kubeconfig: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable"
2025-02-06T09:35:41.972Z [persistenceagent] W0206 09:35:41.972372      81 client_config.go:659] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
2025-02-06T09:35:41.972Z [persistenceagent] W0206 09:35:41.972415      81 client_config.go:664] error creating inClusterConfig, falling back to default config: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined
2025-02-06T09:35:41.972Z [persistenceagent] time="2025-02-06T09:35:41Z" level=fatal msg="Error building kubeconfig: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable"

 ```