### PR TITLE
chore: bump schedworkflows 2.3.0 -> 2.4.0

### DIFF
--- a/scheduledworkflow/rockcraft.yaml
+++ b/scheduledworkflow/rockcraft.yaml
@@ -1,9 +1,9 @@
-# Based on: https://github.com/kubeflow/pipelines/blob/2.3.0/backend/Dockerfile.scheduledworkflow
+# Based on: https://github.com/kubeflow/pipelines/blob/2.4.0/backend/Dockerfile.scheduledworkflow
 name: scheduledworkflow
 summary: Reusable end-to-end ML workflows built using the Kubeflow Pipelines SDK
 description: |
   This component serves as the backend scheduled workflow of Kubeflow pipelines.
-version: "2.3.0"
+version: "2.4.0"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:
@@ -30,9 +30,9 @@ parts:
   controller:
     plugin: go
     source: https://github.com/kubeflow/pipelines.git
-    source-tag: 2.3.0
+    source-tag: 2.4.0
     build-snaps:
-      - go/1.21/stable
+      - go/1.22/stable
     build-environment:
       - GO111MODULE: "on"
     override-build: |


### PR DESCRIPTION
Bump the rock 2.3.0 -> 2.4.0 in preparation for a new release.

The diff between the two versions of the Dockerfile is:

```diff
< FROM golang:1.21.7-alpine3.19 as builder
---
> FROM golang:1.22.10-alpine3.21 as builder
17a18,25
>
> COPY ./go.mod ./
> COPY ./go.sum ./
> COPY ./hack/install-go-licenses.sh ./hack/
>
> RUN GO111MODULE=on go mod download
> RUN ./hack/install-go-licenses.sh
>
26d33
< RUN ./hack/install-go-licenses.sh
```

Which shows a difference in golang version. It also shows a copy of go.mod, and go.sum, and go mod download, which is not required as the go plugin will take care of this.