### PR TITLE
chore: bump viewer 2.3.0 -> 2.4.0

### DIFF
--- a/viewer-crd-controller/rockcraft.yaml
+++ b/viewer-crd-controller/rockcraft.yaml
@@ -1,9 +1,9 @@
-# Based on: https://github.com/kubeflow/pipelines/blob/2.3.0/backend/Dockerfile.viewercontroller
+# Based on: https://github.com/kubeflow/pipelines/blob/2.4.0/backend/Dockerfile.viewercontroller
 name: viewer-crd-controller
 summary: An image for the Viewer CRD Controller
 description: |
   This image is used as part of the Charmed Kubeflow product.
-version: "2.3.0"
+version: "2.4.0"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:
@@ -24,9 +24,9 @@ parts:
     plugin: go
     source: https://github.com/kubeflow/pipelines
     build-snaps:
-      - go/1.21/stable
+      - go/1.22/stable
     source-type: git
-    source-tag: 2.3.0
+    source-tag: 2.4.0
     build-packages:
       - git
       - gcc


### PR DESCRIPTION
Bump the rock 2.3.0 -> 2.4.0 in preparation for a new release.

The diff between the two Dockerfiles is:

```diff
< FROM golang:1.21.7-alpine3.19 as builder
---
> FROM golang:1.22.10-alpine3.21 as builder
20a21,28
>
> COPY ./go.mod ./
> COPY ./go.sum ./
> COPY ./hack/install-go-licenses.sh ./hack/
>
> RUN GO111MODULE=on go mod download
> RUN ./hack/install-go-licenses.sh
>
25d32
< RUN ./hack/install-go-licenses.sh
```

This only shows a bump in the golang version and changes in the go binary build command, which are already handled by the rock's go plugin.