### PR TITLE
chore: upgrade driver 2.4.0 -> 2.4.1

### DIFF
--- a/driver/rockcraft.yaml
+++ b/driver/rockcraft.yaml
@@ -1,8 +1,8 @@
-# Based on: https://github.com/kubeflow/pipelines/blob/2.4.0/backend/Dockerfile.driver
+# Based on: https://github.com/kubeflow/pipelines/blob/2.4.1/backend/Dockerfile.driver
 name: kfp-driver
 summary: Kubeflow Pipelines Driver
 description: This image is used as part of the Charmed Kubeflow product
-version: 2.4.0
+version: 2.4.1
 license: Apache-2.0
 base: ubuntu@22.04
 run-user: _daemon_
@@ -30,7 +30,7 @@ parts:
     source-type: git    
     source: https://github.com/kubeflow/pipelines.git
     source-depth: 1
-    source-tag: 2.4.0   
+    source-tag: 2.4.1   
     build-snaps:
       - go/1.22/stable
     build-packages:
@@ -47,13 +47,5 @@ parts:
       set -xe
 
       mkdir -p $CRAFT_PART_INSTALL/bin
-      mkdir -p $CRAFT_PART_INSTALL/third_party
       
       go build -tags netgo -gcflags="${GCFLAGS}" -ldflags '-extldflags "-static"' -o $CRAFT_PART_INSTALL/bin/driver $CRAFT_PART_BUILD/backend/src/v2/cmd/driver/*.go
-
-      ./hack/install-go-licenses.sh
-
-      $GOBIN/go-licenses check $CRAFT_PART_BUILD/backend/src/v2/cmd/driver
-      $GOBIN/go-licenses csv $CRAFT_PART_BUILD/backend/src/v2/cmd/driver > $CRAFT_PART_INSTALL/third_party/licenses.csv && \
-      diff $CRAFT_PART_INSTALL/third_party/licenses.csv $CRAFT_PART_BUILD/backend/third_party_licenses/driver.csv && \
-      $GOBIN/go-licenses save $CRAFT_PART_BUILD/backend/src/v2/cmd/driver --save_path $CRAFT_PART_INSTALL/third_party/NOTICES

--- a/driver/tests/test_rock.py
+++ b/driver/tests/test_rock.py
@@ -15,36 +15,6 @@ def test_rock():
     rock_version = check_rock.get_version()
     LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
 
-    # assert the rock contains the expected files
-    subprocess.run(
-        [
-            "docker",
-            "run",
-            "--rm",
-            LOCAL_ROCK_IMAGE,
-            "exec",
-            "ls",
-            "-la",
-            "/third_party/licenses.csv",
-        ],
-        check=True,
-    )
-
-    # Assert the rock contains the expected file in /third_party
-    subprocess.run(
-        [
-            "docker",
-            "run",
-            "--rm",
-            LOCAL_ROCK_IMAGE,
-            "exec",
-            "ls",
-            "-la",
-            "/third_party/NOTICES/",
-        ],
-        check=True,
-    )
-
     subprocess.run(
         ["docker", "run", "--rm", LOCAL_ROCK_IMAGE, "exec", "ls", "-la", "/bin/driver"],
         check=True,


### PR DESCRIPTION
This commit upgrades the driver rock in preparation for a new release.

These changes are based on the differences between the Dockerfile v2.4.0 and 2.4.1:

```diff
23d22
< COPY ./hack/install-go-licenses.sh ./hack/
26d24
< RUN ./hack/install-go-licenses.sh
32,38d29
< # Check licenses and comply with license terms.
< # First, make sure there's no forbidden license.
< RUN go-licenses check ./backend/src/v2/cmd/driver
< RUN go-licenses csv ./backend/src/v2/cmd/driver > /tmp/licenses.csv && \
<     diff /tmp/licenses.csv backend/third_party_licenses/driver.csv && \
<     go-licenses save ./backend/src/v2/cmd/driver --save_path /tmp/NOTICES
<
47,49d37
< # Copy licenses and notices.
< COPY --from=builder /tmp/licenses.csv /third_party/licenses.csv
< COPY --from=builder /tmp/NOTICES /third_party/NOTICES
```

Fixes #187 