### PR TITLE
chore: upgrade viewer-crd-controller 2.4.0 -> 2.4.1

### DIFF
--- a/viewer-crd-controller/rockcraft.yaml
+++ b/viewer-crd-controller/rockcraft.yaml
@@ -1,9 +1,9 @@
-# Based on: https://github.com/kubeflow/pipelines/blob/2.4.0/backend/Dockerfile.viewercontroller
+# Based on: https://github.com/kubeflow/pipelines/blob/2.4.1/backend/Dockerfile.viewercontroller
 name: viewer-crd-controller
 summary: An image for the Viewer CRD Controller
 description: |
   This image is used as part of the Charmed Kubeflow product.
-version: "2.4.0"
+version: "2.4.1"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:
@@ -26,7 +26,7 @@ parts:
     build-snaps:
       - go/1.22/stable
     source-type: git
-    source-tag: 2.4.0
+    source-tag: 2.4.1
     build-packages:
       - git
       - gcc
@@ -37,14 +37,8 @@ parts:
       - GO111MODULE: "on"
     override-build: |
       mkdir -p $CRAFT_PART_INSTALL/bin
-      mkdir -p $CRAFT_PART_INSTALL/third_party
 
       go build -o $CRAFT_PART_INSTALL/bin/controller backend/src/crd/controller/viewer/*.go
-      ./hack/install-go-licenses.sh
-      $GOBIN/go-licenses check ./backend/src/crd/controller/viewer
-      $GOBIN/go-licenses csv ./backend/src/crd/controller/viewer > $CRAFT_PART_INSTALL/third_party/licenses.csv
-      diff $CRAFT_PART_INSTALL/third_party/licenses.csv backend/third_party_licenses/viewer.csv
-      $GOBIN/go-licenses save --force ./backend/src/crd/controller/viewer --save_path $CRAFT_PART_INSTALL/third_party/NOTICES
 
   security-team-requirement:
     plugin: nil

--- a/viewer-crd-controller/tests/test_rock.py
+++ b/viewer-crd-controller/tests/test_rock.py
@@ -42,15 +42,3 @@ def test_rock(rock_test_env):
         ],
         check=True,
     )
-    subprocess.run(
-        [
-            "docker",
-            "run",
-            "--entrypoint",
-            "/bin/bash",
-            LOCAL_ROCK_IMAGE,
-            "-c",
-            "ls -la /third_party",
-        ],
-        check=True,
-    )


### PR DESCRIPTION
This commit upgrades the viewer-crd-controller rock in preparation for a new release.

Fixes #185

Changes were done based on the differences between the two versions of the Dockerfiles:

```diff
24d23
< COPY ./hack/install-go-licenses.sh ./hack/
27d25
< RUN ./hack/install-go-licenses.sh
32,37d29
< # Check licenses and comply with license terms.
< # First, make sure there's no forbidden license.
< RUN go-licenses check ./backend/src/crd/controller/viewer
< RUN go-licenses csv ./backend/src/crd/controller/viewer > /tmp/licenses.csv && \
<     diff /tmp/licenses.csv backend/third_party_licenses/viewer.csv && \
<     go-licenses save ./backend/src/crd/controller/viewer --save_path /tmp/NOTICES
45,47d36
< # Copy licenses and notices.
< COPY --from=builder /tmp/licenses.csv /third_party/licenses.csv
< COPY --from=builder /tmp/NOTICES /third_party/NOTICES
```