### PR TITLE
chore: upgrade scheduledworkflow 2.4.0 -> 2.4.1

### DIFF
--- a/scheduledworkflow/rockcraft.yaml
+++ b/scheduledworkflow/rockcraft.yaml
@@ -1,9 +1,9 @@
-# Based on: https://github.com/kubeflow/pipelines/blob/2.4.0/backend/Dockerfile.scheduledworkflow
+# Based on: https://github.com/kubeflow/pipelines/blob/2.4.1/backend/Dockerfile.scheduledworkflow
 name: scheduledworkflow
 summary: Reusable end-to-end ML workflows built using the Kubeflow Pipelines SDK
 description: |
   This component serves as the backend scheduled workflow of Kubeflow pipelines.
-version: "2.4.0"
+version: "2.4.1"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:
@@ -30,16 +30,10 @@ parts:
   controller:
     plugin: go
     source: https://github.com/kubeflow/pipelines.git
-    source-tag: 2.4.0
+    source-tag: 2.4.1
     build-snaps:
       - go/1.22/stable
     build-environment:
       - GO111MODULE: "on"
     override-build: |
-      mkdir -p $CRAFT_PART_INSTALL/third_party
       go build -o $CRAFT_PART_INSTALL/bin/controller backend/src/crd/controller/scheduledworkflow/*.go
-      ./hack/install-go-licenses.sh
-      $GOBIN/go-licenses check ./backend/src/crd/controller/scheduledworkflow
-      $GOBIN/go-licenses csv ./backend/src/crd/controller/scheduledworkflow > $CRAFT_PART_INSTALL/third_party/licenses.csv && \
-       diff $CRAFT_PART_INSTALL/third_party/licenses.csv backend/third_party_licenses/swf.csv && \
-       $GOBIN/go-licenses save ./backend/src/crd/controller/scheduledworkflow --save_path $CRAFT_PART_INSTALL/third_party/NOTICES

--- a/scheduledworkflow/tests/test_rock.py
+++ b/scheduledworkflow/tests/test_rock.py
@@ -45,15 +45,3 @@ def test_rock(rock_test_env):
         ],
         check=True,
     )
-    subprocess.run(
-        [
-            "docker",
-            "run",
-            "--entrypoint",
-            "/bin/bash",
-            LOCAL_ROCK_IMAGE,
-            "-c",
-            "ls -la /third_party",
-        ],
-        check=True,
-    )


### PR DESCRIPTION
This commit upgrades the scheduledworkflow rock in preparation for a new release.

Fixes #184

This PR is based on the differences between both versions of the upstream Dockerfile:

```diff
21d20
< COPY ./hack/install-go-licenses.sh ./hack/
24d22
< RUN ./hack/install-go-licenses.sh
33,38d30
< # Check licenses and comply with license terms.
< # First, make sure there's no forbidden license.
< RUN go-licenses check ./backend/src/crd/controller/scheduledworkflow
< RUN go-licenses csv ./backend/src/crd/controller/scheduledworkflow > /tmp/licenses.csv && \
<     diff /tmp/licenses.csv backend/third_party_licenses/swf.csv && \
<     go-licenses save ./backend/src/crd/controller/scheduledworkflow --save_path /tmp/NOTICES
50,53d41
< # Copy licenses and notices.
< COPY --from=builder /tmp/licenses.csv /third_party/licenses.csv
< COPY --from=builder /tmp/NOTICES /third_party/NOTICES
<
```