### PR TITLE
chore: upgrade launcher 2.4.0 -> 2.4.1

### DIFF
--- a/launcher/rockcraft.yaml
+++ b/launcher/rockcraft.yaml
@@ -1,9 +1,9 @@
-# Based on: https://github.com/kubeflow/pipelines/blob/2.4.0/backend/Dockerfile.launcher
+# Based on: https://github.com/kubeflow/pipelines/blob/2.4.1/backend/Dockerfile.launcher
 name: kfp-launcher
 summary: Kubeflow Pipelines Launcher
 description: |
   Kubeflow Pipelines Launcher is a streamlined interface designed to simplify the creation, management, and deployment of machine learning workflows on Kubernetes.
-version: 2.4.0
+version: 2.4.1
 license: Apache-2.0
 base: ubuntu@22.04
 run-user: _daemon_
@@ -31,7 +31,7 @@ parts:
     source-type: git    
     source: https://github.com/kubeflow/pipelines.git
     source-depth: 1
-    source-tag: 2.4.0   
+    source-tag: 2.4.1   
     build-snaps:
       - go/1.22/stable
     build-packages:
@@ -47,14 +47,4 @@ parts:
       set -xe
 
       mkdir -p $CRAFT_PART_INSTALL/bin
-      mkdir -p $CRAFT_PART_INSTALL/third_party
-      
       go build -tags netgo -ldflags '-extldflags "-static"' -o $CRAFT_PART_INSTALL/bin/launcher-v2 $CRAFT_PART_BUILD/backend/src/v2/cmd/launcher-v2/*.go
-
-      ./hack/install-go-licenses.sh
-
-      $GOBIN/go-licenses check $CRAFT_PART_BUILD/backend/src/v2/cmd/launcher-v2
-      $GOBIN/go-licenses csv $CRAFT_PART_BUILD/backend/src/v2/cmd/launcher-v2 > $CRAFT_PART_INSTALL/third_party/licenses.csv && \
-      diff $CRAFT_PART_INSTALL/third_party/licenses.csv $CRAFT_PART_BUILD/backend/third_party_licenses/launcher.csv && \
-      $GOBIN/go-licenses save $CRAFT_PART_BUILD/backend/src/v2/cmd/launcher-v2 --save_path $CRAFT_PART_INSTALL/third_party/NOTICES
-

--- a/launcher/tests/test_rock.py
+++ b/launcher/tests/test_rock.py
@@ -15,36 +15,6 @@ def test_rock():
     rock_version = check_rock.get_version()
     LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
 
-    # assert the rock contains the expected files
-    subprocess.run(
-        [
-            "docker",
-            "run",
-            "--rm",
-            LOCAL_ROCK_IMAGE,
-            "exec",
-            "ls",
-            "-la",
-            "/third_party/licenses.csv",
-        ],
-        check=True,
-    )
-
-    # Assert the rock contains the expected file in /third_party
-    subprocess.run(
-        [
-            "docker",
-            "run",
-            "--rm",
-            LOCAL_ROCK_IMAGE,
-            "exec",
-            "ls",
-            "-la",
-            "/third_party/NOTICES/",
-        ],
-        check=True,
-    )
-
     subprocess.run(
         ["docker", "run", "--rm", LOCAL_ROCK_IMAGE, "exec", "ls", "-la", "/bin/launcher-v2"],
         check=True,


### PR DESCRIPTION
This commit upgrades the launcher rock in preparation for a new release.

Fixes #180

Changes based on the differences between both versions of the upstream Dockerfiles:

```diff
21d20
< COPY ./hack/install-go-licenses.sh ./hack/
24d22
< RUN ./hack/install-go-licenses.sh
30,36d27
< # Check licenses and comply with license terms.
< # First, make sure there's no forbidden license.
< RUN go-licenses check ./backend/src/v2/cmd/launcher-v2
< RUN go-licenses csv ./backend/src/v2/cmd/launcher-v2 > /tmp/licenses.csv && \
<     diff /tmp/licenses.csv backend/third_party_licenses/launcher.csv && \
<     go-licenses save ./backend/src/v2/cmd/launcher-v2 --save_path /tmp/NOTICES
<
45,47d35
< # Copy licenses and notices.
< COPY --from=builder /tmp/licenses.csv /third_party/licenses.csv
< COPY --from=builder /tmp/NOTICES /third_party/NOTICES
```