### PR TITLE
chore: upgrade api-server image to 2.5.0

### DIFF
--- a/api-server/rockcraft.yaml
+++ b/api-server/rockcraft.yaml
@@ -111,6 +111,13 @@ parts:
       # These are set at build in dockerfile (those are just links to examples)
       - COMMIT_SHA: unknown
       - TAG_NAME: unknown
+    overlay-packages:
+      # NOTE: "ca-certificates" installed among "overlay-packages" instead of
+      # "stage-packages" as a workaround to this issue:
+      # https://github.com/canonical/rockcraft/issues/334
+      - ca-certificates
+    stage-packages:
+      - wget
     override-build: |
       cp -r $CRAFT_STAGE/config/ $CRAFT_PART_INSTALL/config
       mkdir -p $CRAFT_PART_INSTALL/bin
@@ -119,10 +126,3 @@ parts:
 
       sed -E "s#/(blob|tree)/master/#/\1/${COMMIT_SHA}/#g" -i $CRAFT_PART_INSTALL/config/sample_config.json
       sed -E "s/%252Fmaster/%252F${COMMIT_SHA}/#g" -i $CRAFT_PART_INSTALL/config/sample_config.json
-    overlay-packages:
-      # NOTE: "ca-certificates" installed among "overlay-packages" instead of
-      # "stage-packages" as a workaround to this issue:
-      # https://github.com/canonical/rockcraft/issues/334
-      - ca-certificates
-    stage-packages:
-      - wget


### PR DESCRIPTION
Addressing https://github.com/canonical/pipelines-rocks/issues/210.

**NOTES:**
- being the upstream base image still based on Debian Bookworm (see [the golang image tag meanings](https://hub.docker.com/_/golang#image-variants)), Ubuntu 22.04 is still the compatible base for rock parts
- the opportunity was taken to move the installation of some packages to the appropriate steps of the "server" part