### PR TITLE
chore: upgrade driver image to 2.5.0

### DIFF
--- a/driver/rockcraft.yaml
+++ b/driver/rockcraft.yaml
@@ -1,8 +1,8 @@
-# Based on: https://github.com/kubeflow/pipelines/blob/2.4.1/backend/Dockerfile.driver
+# Based on: https://github.com/kubeflow/pipelines/blob/2.5.0/backend/Dockerfile.driver
 name: kfp-driver
 summary: Kubeflow Pipelines Driver
 description: This image is used as part of the Charmed Kubeflow product
-version: 2.4.1
+version: 2.5.0
 license: Apache-2.0
 base: ubuntu@22.04
 run-user: _daemon_
@@ -30,9 +30,9 @@ parts:
     source-type: git    
     source: https://github.com/kubeflow/pipelines.git
     source-depth: 1
-    source-tag: 2.4.1   
+    source-tag: 2.5.0   
     build-snaps:
-      - go/1.22/stable
+      - go/1.23/stable
     build-packages:
       - apt
       - bash


### PR DESCRIPTION
Addressing https://github.com/canonical/pipelines-rocks/issues/211.