### PR TITLE
chore: upgrade visualization-server image to 2.5.0

### DIFF
--- a/visualization-server/rockcraft.yaml
+++ b/visualization-server/rockcraft.yaml
@@ -1,10 +1,10 @@
-# Based on: https://github.com/kubeflow/pipelines/blob/2.4.1/backend/Dockerfile.visualization
+# Based on: https://github.com/kubeflow/pipelines/blob/2.5.0/backend/Dockerfile.visualization
 name: visualization-server
 summary: ml-pipeline/visualization-server
 description: |
     ml-pipeline/visualization-server
     https://github.com/kubeflow/pipelines/tree/master/backend
-version: "2.4.1"
+version: "2.5.0"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:
@@ -35,7 +35,7 @@ parts:
     plugin: python
     source: https://github.com/kubeflow/pipelines.git
     source-subdir: backend/src/apiserver/visualization
-    source-tag: 2.4.1
+    source-tag: 2.5.0
     stage-packages:
       # sync this python version to that in the tensorflow 
       # base image of Dockerfile.visualization.  Also keep this
@@ -75,6 +75,6 @@ parts:
   files:
     plugin: nil
     source: https://github.com/kubeflow/pipelines.git
-    source-tag: 2.4.1
+    source-tag: 2.5.0
     override-build: |
       cp -r backend/src/apiserver/visualization/* $CRAFT_PART_INSTALL


### PR DESCRIPTION
Addressing https://github.com/canonical/pipelines-rocks/issues/215.