### PR TITLE
chore: upgrade scheduledworkflow image to 2.5.0

### DIFF
--- a/scheduledworkflow/rockcraft.yaml
+++ b/scheduledworkflow/rockcraft.yaml
@@ -1,9 +1,9 @@
-# Based on: https://github.com/kubeflow/pipelines/blob/2.4.1/backend/Dockerfile.scheduledworkflow
+# Based on: https://github.com/kubeflow/pipelines/blob/2.5.0/backend/Dockerfile.scheduledworkflow
 name: scheduledworkflow
 summary: Reusable end-to-end ML workflows built using the Kubeflow Pipelines SDK
 description: |
   This component serves as the backend scheduled workflow of Kubeflow pipelines.
-version: "2.4.1"
+version: "2.5.0"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:
@@ -30,9 +30,9 @@ parts:
   controller:
     plugin: go
     source: https://github.com/kubeflow/pipelines.git
-    source-tag: 2.4.1
+    source-tag: 2.5.0
     build-snaps:
-      - go/1.22/stable
+      - go/1.23/stable
     build-environment:
       - GO111MODULE: "on"
     override-build: |


### PR DESCRIPTION
Addressing https://github.com/canonical/pipelines-rocks/issues/217.