### PR TITLE
chore: upgrade persistenceagent image to 2.5.0

### DIFF
--- a/persistenceagent/rockcraft.yaml
+++ b/persistenceagent/rockcraft.yaml
@@ -1,9 +1,9 @@
-# Based on: https://github.com/kubeflow/pipelines/blob/2.4.1/backend/Dockerfile.persistenceagent
+# Based on: https://github.com/kubeflow/pipelines/blob/2.5.0/backend/Dockerfile.persistenceagent
 name: persistenceagent
 summary: Reusable end-to-end ML workflows built using the Kubeflow Pipelines SDK
 description: |
   This component serves as the backend persistence agent of Kubeflow pipelines.
-version: "2.4.1"
+version: "2.5.0"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:
@@ -35,9 +35,9 @@ parts:
     plugin: go
     source: https://github.com/kubeflow/pipelines
     source-type: git
-    source-tag: 2.4.1
+    source-tag: 2.5.0
     build-snaps:
-      - go/1.22/stable
+      - go/1.23/stable
     build-packages:
       - git
       - openssl


### PR DESCRIPTION
Addressing https://github.com/canonical/pipelines-rocks/issues/218.