### PR TITLE
feat: `frontend` create rocks-automation-ci.yaml

### DIFF
--- a/frontend/rock-ci-metadata.yaml
+++ b/frontend/rock-ci-metadata.yaml
@@ -1,0 +1,8 @@
+integrations:
+  - consumer-repository: https://github.com/canonical/kfp-operators.git
+
+    replace-image:
+      - file: charms/kfp-profile-controller/src/default-custom-images.json
+        path: frontend
+      - file: charms/kfp-ui/metadata.yaml
+        path: resources.ml-pipeline-ui.upstream-source


### PR DESCRIPTION
Closes: https://github.com/canonical/pipelines-rocks/issues/202

This pr: 
- introduces `rock-ci-metadata.yaml` file for rock integration.
**note:** `workflow_dispatch` is already part of repo

For full file creation steps please refer to [this](https://github.com/canonical/pipelines-rocks/issues/200#issuecomment-3112245114) comment.

Issue related to service file https://github.com/canonical/kfp-operators/issues/755