### PR TITLE
feat: `driver` create rocks-automation-ci.yaml

### DIFF
--- a/driver/rock-ci-metadata.yaml
+++ b/driver/rock-ci-metadata.yaml
@@ -1,0 +1,6 @@
+integrations:
+  - consumer-repository: https://github.com/canonical/kfp-operators.git
+   
+    replace-image:
+      - file: charms/kfp-api/config.yaml
+        path: options.driver-image.default


### PR DESCRIPTION
Closes: https://github.com/canonical/pipelines-rocks/issues/201

This pr: 
- introduces `rock-ci-metadata.yaml` file for rock integration.
**note:** `workflow_dispatch` is already part of repo

For full file creation steps please refer to [this](https://github.com/canonical/pipelines-rocks/issues/200#issuecomment-3112245114) comment.

Issue related to service file https://github.com/canonical/kfp-operators/issues/755