### PR TITLE
feat: upgrade persistenceagent to 2.16.0

### DIFF
--- a/persistenceagent/rockcraft.yaml
+++ b/persistenceagent/rockcraft.yaml
@@ -1,9 +1,9 @@
-# Based on: https://github.com/kubeflow/pipelines/blob/2.15.0/backend/Dockerfile.persistenceagent
+# Based on: https://github.com/kubeflow/pipelines/blob/2.16.0/backend/Dockerfile.persistenceagent
 name: persistenceagent
 summary: Reusable end-to-end ML workflows built using the Kubeflow Pipelines SDK
 description: |
   This component serves as the backend persistence agent of Kubeflow pipelines.
-version: "2.15.0"
+version: "2.16.0"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:
@@ -27,7 +27,7 @@ parts:
     plugin: go
     source: https://github.com/kubeflow/pipelines
     source-type: git
-    source-tag: 2.15.0
+    source-tag: 2.16.0
     build-snaps:
       - go/1.24/stable
     build-packages:


### PR DESCRIPTION
Closes: https://github.com/canonical/pipelines-rocks/issues/291

[No diffs](https://www.diffchecker.com/PhWG3VjI/)