### PR TITLE
feat: update visualization-server to 2.16.0

### DIFF
--- a/visualization-server/rockcraft.yaml
+++ b/visualization-server/rockcraft.yaml
@@ -1,10 +1,10 @@
-# Based on: https://github.com/kubeflow/pipelines/blob/2.15.0/backend/Dockerfile.visualization
+# Based on: https://github.com/kubeflow/pipelines/blob/2.16.0/backend/Dockerfile.visualization
 name: visualization-server
 summary: ml-pipeline/visualization-server
 description: |
     ml-pipeline/visualization-server
     https://github.com/kubeflow/pipelines/tree/master/backend
-version: "2.15.0"
+version: "2.16.0"
 license: Apache-2.0
 base: ubuntu@24.04
 package-repositories:
@@ -32,21 +32,21 @@ parts:
     plugin: python
     source: https://github.com/kubeflow/pipelines.git
     source-subdir: backend/src/apiserver/visualization
-    source-tag: 2.15.0
+    source-tag: 2.16.0
     build-packages:
       - python3.11-venv
     stage-packages:
       - python3.11-venv
     python-requirements:
     - requirements.txt
-    build-environment: 
+    build-environment:
     - PARTS_PYTHON_INTERPRETER: python3.11
     override-build: |
       craftctl default
       # Ensure Python 3.11 is the default version
       mkdir -p ${CRAFT_PART_INSTALL}/usr/bin/
       ln -fs /usr/bin/python3.11 ${CRAFT_PART_INSTALL}/usr/bin/python3
-  
+
   gcloud:
     plugin: nil
     stage-packages:
@@ -57,16 +57,22 @@ parts:
     build-environment:
     # Adding this env variable prevents the gcloud sdk installer from showing prompts
     - CLOUDSDK_CORE_DISABLE_PROMPTS: 1
+    - CLOUD_SDK_VERSION: 557.0.0
+    - CLOUD_SDK_SHA256: 6b048c0cb3057517a2a71e94a5a2a712fe7d30c6928f73e458bd5946187ca470
     override-build: |
       set -x
-      curl https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz > /tmp/google-cloud-sdk.tar.gz
+
+      curl -fsSL "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz" \
+       -o tmp/google-cloud-sdk.tar.gz
+      echo "${CLOUD_SDK_SHA256}  /tmp/google-cloud-sdk.tar.gz" | sha256sum -c -
       mkdir -p "${CRAFT_PART_INSTALL}"/usr/local/gcloud
       tar -C "${CRAFT_PART_INSTALL}"/usr/local/gcloud -xf /tmp/google-cloud-sdk.tar.gz
       "${CRAFT_PART_INSTALL}"/usr/local/gcloud/google-cloud-sdk/install.sh
+      rm /tmp/google-cloud-sdk.tar.gz
 
   files:
     plugin: nil
     source: https://github.com/kubeflow/pipelines.git
-    source-tag: 2.15.0
+    source-tag: 2.16.0
     override-build: |
       cp -r backend/src/apiserver/visualization/* $CRAFT_PART_INSTALL

--- a/visualization-server/rockcraft.yaml
+++ b/visualization-server/rockcraft.yaml
@@ -62,6 +62,7 @@ parts:
     override-build: |
       set -x
 
+      rm -rf /var/lib/apt/lists/*
       curl -fsSL "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz" \
        -o /tmp/google-cloud-sdk.tar.gz
       echo "${CLOUD_SDK_SHA256}  /tmp/google-cloud-sdk.tar.gz" | sha256sum -c -

--- a/visualization-server/rockcraft.yaml
+++ b/visualization-server/rockcraft.yaml
@@ -63,7 +63,7 @@ parts:
       set -x
 
       curl -fsSL "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz" \
-       -o tmp/google-cloud-sdk.tar.gz
+       -o /tmp/google-cloud-sdk.tar.gz
       echo "${CLOUD_SDK_SHA256}  /tmp/google-cloud-sdk.tar.gz" | sha256sum -c -
       mkdir -p "${CRAFT_PART_INSTALL}"/usr/local/gcloud
       tar -C "${CRAFT_PART_INSTALL}"/usr/local/gcloud -xf /tmp/google-cloud-sdk.tar.gz


### PR DESCRIPTION
Closes https://github.com/canonical/pipelines-rocks/issues/294

## Notes
- The `rm /var/lib/apt/lists/*` is unnecessary since the directory is already empty. This is because the rock doesn't run `apt get update`, but we're keeping it for compatibility reasons.
- The `rm` command I added at the end is unnecessary (since the `/tmp` directory is in the LXD container and not the final image), but I'm keeping it to align with the upstream.

[Diff](https://www.diffchecker.com/6M3ZlTdr/)