### PR TITLE
feat: implement cachce server

### DIFF
--- a/cache-server/rock-ci-metadata.yaml
+++ b/cache-server/rock-ci-metadata.yaml
@@ -1,0 +1,1 @@
+integrations: []

--- a/cache-server/rockcraft.yaml
+++ b/cache-server/rockcraft.yaml
@@ -11,7 +11,7 @@ platforms:
 
 services:
   cache-server:
-    override: merge
+    override: replace
     summary: "kfp cache server service"
     startup: enabled
     command: "/bin/cache_server"

--- a/cache-server/rockcraft.yaml
+++ b/cache-server/rockcraft.yaml
@@ -1,0 +1,54 @@
+# Based on: https://github.com/kubeflow/pipelines/blob/2.16.0/backend/Dockerfile.cacheserver
+name: cache-server
+summary: Kubeflow Pipelines Cache Server
+description: This image is used as part of the Charmed Kubeflow product
+version: 2.16.0
+license: Apache-2.0
+base: ubuntu@22.04
+run-user: _daemon_
+platforms:
+  amd64:
+
+services:
+  cache-server:
+    override: merge
+    summary: "kfp cache server service"
+    startup: enabled
+    command: "/bin/cache_server"
+
+parts:
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+       dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > \
+       ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+
+  cache-server:
+    plugin: go
+    source-type: git    
+    source: https://github.com/kubeflow/pipelines.git
+    source-depth: 1
+    source-tag: 2.16.0   
+    build-snaps:
+      - go/1.24/stable
+    build-packages:
+      - apt
+      - bash
+      - gcc
+      - musl-dev
+    build-environment:
+      - GO111MODULE: "on"
+      - CGO_ENABLED: 0
+      - GOOS: linux
+      - GOARCH: amd64
+    stage-packages:
+      - ca-certificates
+      - bash      
+    override-build: |
+      set -xe
+
+      mkdir -p $CRAFT_PART_INSTALL/bin
+      
+      go build -o $CRAFT_PART_INSTALL/bin/cache_server $CRAFT_PART_BUILD/backend/src/cache/*.go

--- a/cache-server/rockcraft.yaml
+++ b/cache-server/rockcraft.yaml
@@ -17,14 +17,6 @@ services:
     command: "/bin/cache_server"
 
 parts:
-  security-team-requirement:
-    plugin: nil
-    override-build: |
-      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
-      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
-       dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > \
-       ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
-
   cache-server:
     plugin: go
     source-type: git    
@@ -52,3 +44,22 @@ parts:
       mkdir -p $CRAFT_PART_INSTALL/bin
       
       go build -o $CRAFT_PART_INSTALL/bin/cache_server $CRAFT_PART_BUILD/backend/src/cache/*.go
+  
+  non-root-user:
+    after:
+      - cache-server
+    plugin: nil
+    override-prime: |
+      craftctl default
+      install -d -o 584792 -g 584792 -m 770 \
+        etc/webhook/certs
+  
+  security-team-requirement:
+    after:
+      - non-root-user
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+       dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > \
+       ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query

--- a/cache-server/tests/test_rock.py
+++ b/cache-server/tests/test_rock.py
@@ -1,0 +1,21 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import pytest
+import subprocess
+
+from charmed_kubeflow_chisme.rock import CheckRock
+
+
+@pytest.mark.abort_on_fail
+def test_rock():
+    """Test rock."""
+    check_rock = CheckRock("rockcraft.yaml")
+    rock_image = check_rock.get_name()
+    rock_version = check_rock.get_version()
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
+
+    subprocess.run(
+        ["docker", "run", "--rm", LOCAL_ROCK_IMAGE, "exec", "ls", "-la", "/bin/cache_server"],
+        check=True,
+    )

--- a/cache-server/tox.ini
+++ b/cache-server/tox.ini
@@ -1,0 +1,53 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+envlist = pack, export-to-docker, unit, sanity, integration
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+    CHARM_REPO=https://github.com/canonical/kfp-operators.git
+    CHARM_BRANCH=main
+    LOCAL_CHARM_DIR=charm_repo
+
+[testenv:pack]
+passenv = *
+allowlist_externals =
+    rockcraft
+commands =
+    rockcraft pack
+
+[testenv:export-to-docker]
+passenv = *
+allowlist_externals =
+    bash
+    skopeo
+    yq
+commands =
+    # export to docker
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys | .[0]" rockcraft.yaml) && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
+             DOCKER_IMAGE=$NAME:$VERSION && \
+             echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
+             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+
+[testenv:sanity]
+passenv = *
+deps =
+    pytest
+    charmed-kubeflow-chisme
+commands =
+    pytest -s -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+
+[testenv:integration]
+passenv = *
+allowlist_externals =
+    echo
+commands =
+    # TODO: Implement integration tests here
+    echo "WARNING: This is a placeholder test - no test is implemented here."


### PR DESCRIPTION
Closes: https://github.com/canonical/pipelines-rocks/issues/305

This rock is not yet used in the charms. 

### Testing
I have compared with upstream docker image. Logs: 
```
ubuntu@rockcraft-builder:~$  docker exec -ti 669e729312bd bash
_daemon_@669e729312bd:/$ pebble logs
2026-04-29T08:37:30.636Z [cache-server] 2026/04/29 08:37:30 Initing client manager....
_daemon_@669e729312bd:/$ ^C
_daemon_@669e729312bd:/$ 
exit
ubuntu@rockcraft-builder:~$ docker run ghcr.io/kubeflow/kfp-cache-server
Unable to find image 'ghcr.io/kubeflow/kfp-cache-server:latest' locally
latest: Pulling from kubeflow/kfp-cache-server
a293eccac045: Pull complete 
619c4d760777: Pull complete 
bc1da058f299: Pull complete 
4f4fb700ef54: Pull complete 
Digest: sha256:edeba636f4adb4cef5a68991023e31108005e3c600db11a3d35cb5c44fefce83
Status: Downloaded newer image for ghcr.io/kubeflow/kfp-cache-server:latest
2026/04/29 08:39:07 Initing client manager....
```

I have also compared packages present in both of images.