### PR TITLE
chore: remove unused parameters and add backport automation

### DIFF
--- a/.github/automatic_backport_tracks.yaml
+++ b/.github/automatic_backport_tracks.yaml
@@ -1,0 +1,3 @@
+automatic_backport_tracks:
+  -   track/2.5
+  -   track/2.15

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -4,13 +4,17 @@ on:
   pull_request:
 
 jobs:
+  populate-labels:
+    name: Populate labels
+    if: github.base_ref == 'main' && (github.event.action == 'opened' || github.event.action == 'reopened')
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/populate-labels.yaml@main
+    secrets: inherit
+    with:
+      track_file_path: ".github/automatic_backport_tracks.yaml"
+      label_prefix: "backport "
 
   on-pull-request:
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/get-rocks-modified-and-build-scan-test-publish.yaml@main
     permissions:
       pull-requests: read
     secrets: inherit
-    with:
-      microk8s-channel: 1.32-strict/stable
-      juju-channel: 3.6/stable
-      python-version: "3.8"

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -1,5 +1,9 @@
 name: On PR
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
 

--- a/.github/workflows/on_pull_request_closed.yaml
+++ b/.github/workflows/on_pull_request_closed.yaml
@@ -1,0 +1,23 @@
+name: On Pull Request Closed
+
+# When a pull request is pushed on the main branch, automatically
+# create backport PRs according to the labels on the pull request.
+# If there are conflicts, create a PR but leave it as draft.
+
+on:
+  pull_request_target:
+    types: [closed]
+    branches:
+    - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+
+  backport:
+    name: Backport pull request
+    if: github.event.pull_request.merged
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/backport-pr.yaml@main
+    secrets: inherit

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -13,7 +13,3 @@ jobs:
     permissions:
       pull-requests: read
     secrets: inherit
-    with:
-      microk8s-channel: 1.32-strict/stable
-      juju-channel: 3.6/stable
-      python-version: "3.8"


### PR DESCRIPTION
This PR removes the unused input parameters from the Build workflow.
This is necessary to eventually address canonical/charmed-kubeflow-workflows/issues/136.

This PR also adds a concurrency group so that previous jobs regarding the same PRs are cancelled.

This PR also adds backport automation for tracks `2.5` and `2.15`.