### PR TITLE
fix: pass base branch properly

### DIFF
--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -10,6 +10,8 @@ jobs:
 
   on-push:
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/get-rocks-modified-and-build-scan-test-publish.yaml@main
+    with:
+      base-ref: ${{ github.ref_name }}
     permissions:
       pull-requests: read
     secrets: inherit


### PR DESCRIPTION
See context here: canonical/kubeflow-trainer-rocks/pull/9